### PR TITLE
Rotatable Bonds and Virtual Sites Clean-up

### DIFF
--- a/QUBEKit/dihedrals.py
+++ b/QUBEKit/dihedrals.py
@@ -83,8 +83,10 @@ class TorsionScan:
 
         # Get the rotatable dihedrals from the molecule
         self.molecule.scan_order = []
-        if self.molecule.rotatable_bonds is None:
+        rotatables_bonds = self.molecule.find_rotatable_bonds()
+        if rotatables_bonds is None:
             return
+        rotatables_bonds = [bond.indices for bond in rotatables_bonds]
 
         rotatable = set()
         non_rotatable = set()
@@ -92,7 +94,7 @@ class TorsionScan:
         for dihedral_class in self.molecule.dihedral_types.values():
             dihedral = dihedral_class[0]
             bond = dihedral[1:3]
-            if bond in self.molecule.rotatable_bonds:
+            if bond in rotatables_bonds:
                 rotatable.add(bond)
             else:
                 non_rotatable.add(dihedral)

--- a/QUBEKit/molecules/components.py
+++ b/QUBEKit/molecules/components.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from pydantic import BaseModel, Field, PositiveInt
 from rdkit import Chem
@@ -242,6 +242,10 @@ class Bond(BaseModel):
         elif self.stereochemistry == "Z":
             return Chem.BondStereo.STEREOZ
         return None
+
+    @property
+    def indices(self) -> Tuple[int, int]:
+        return self.atom1_index, self.atom2_index
 
 
 class ExtraSite:

--- a/QUBEKit/tests/ligand/ligand_test.py
+++ b/QUBEKit/tests/ligand/ligand_test.py
@@ -215,35 +215,6 @@ def test_n_atoms(acetone):
     assert acetone.n_atoms == 10
 
 
-def test_rotatable_bonds_filtered(acetone):
-    """
-    For acetone while there are dihedrals we do not class these as rotatable as they are methyl, make sure
-    this is true.
-    """
-    assert acetone.rotatable_bonds is None
-    assert acetone.n_rotatable_bonds == 0
-
-
-def test_no_rotatable_bonds():
-    """
-    If there are no dihedrals in the molecule make sure we return None.
-    """
-    mol = Ligand.from_file(file_name=get_data("water.pdb"))
-    assert mol.rotatable_bonds is None
-    assert mol.n_rotatable_bonds == 0
-
-
-def test_rotatable_bonds():
-    """
-    Make sure we can find true rotatable bonds for a molecule.
-    """
-    mol = Ligand.from_file(file_name=get_data("biphenyl.pdb"))
-    assert mol.rotatable_bonds == [
-        (3, 4),
-    ]
-    assert mol.n_rotatable_bonds == 1
-
-
 def test_atom_types(acetone):
     """
     Make sure we can assign atom types to a molecule based on the CIP rank.

--- a/QUBEKit/tests/ligand/ligand_test.py
+++ b/QUBEKit/tests/ligand/ligand_test.py
@@ -710,7 +710,10 @@ def test_find_rotatable_bonds_n_rotatables(molecule, n_rotatables):
     Ensure the number of rotatable bonds found matches the expected.
     """
     mol = Ligand.from_file(get_data(molecule))
-    assert len(mol.find_rotatable_bonds(["[*:1]-[CH3:2]", "[*:1]-[NH2:2]"])) == n_rotatables
+    assert (
+        len(mol.find_rotatable_bonds(["[*:1]-[CH3:2]", "[*:1]-[NH2:2]"]))
+        == n_rotatables
+    )
 
 
 @pytest.mark.parametrize(
@@ -718,7 +721,7 @@ def test_find_rotatable_bonds_n_rotatables(molecule, n_rotatables):
     [
         pytest.param("pyridine.pdb", id="pyridinepdb"),
         pytest.param("chloromethane.pdb", id="chloromethanepdb"),
-    ]
+    ],
 )
 def test_find_rotatable_bonds_no_rotatables(molecule):
     """

--- a/QUBEKit/utils/file_handling.py
+++ b/QUBEKit/utils/file_handling.py
@@ -1,8 +1,11 @@
+#!/usr/bin/env python3
+
 """
 Purpose of this file is to read various inputs and produce the info required for
     Ligand() or Protein()
 Should be very little calculation here, simply file reading and some small validations / checks
 """
+
 import os
 
 import numpy as np

--- a/QUBEKit/virtual_sites.py
+++ b/QUBEKit/virtual_sites.py
@@ -79,20 +79,6 @@ class VirtualSites:
         # [((x, y, z), q, atom_index), ... ]
         self.v_sites_coords: List[Tuple[np.ndarray, float, int]] = []
 
-        # Kept separate for graphing comparisons
-        # These lists are reset for each atom with (a) virtual site - unlike v_sites_coords
-        # [((x, y, z), q, atom_index)]
-        self.one_site_coords: Optional[List[Tuple[np.ndarray, float, int]]] = None
-        # [((x, y, z), q, atom_index), ((x, y, z), q, atom_index)]
-        self.two_site_coords: Optional[List[Tuple[np.ndarray, float, int]]] = None
-
-        # Reset for each new atom; initial params are irrelevant.
-        self.site_errors: Dict[int, float] = {
-            0: 5,
-            1: 10,
-            2: 15,
-        }
-
         self.sample_points: Optional[List[np.ndarray]] = None
         self.no_site_esps: Optional[List[np.ndarray]] = None
 
@@ -668,9 +654,132 @@ class VirtualSites:
         """
         return 1 - x[2] ** 2 - x[3] ** 2
 
+    def fit_one_site(self, atom_index):
+        """
+        Fit method for one site whose parent is <atom_index>
+        """
+        vec = self.get_vector_from_coords(atom_index, n_sites=1)
+        bounds = ((-1.0, 1.0), (-1.0, 1.0))
+        one_site_fit = minimize(
+            self.one_site_objective_function,
+            np.array([0, 1]),
+            args=(atom_index, vec),
+            bounds=bounds,
+        )
+        error = one_site_fit.fun / len(self.sample_points)
+        q, lam = one_site_fit.x
+        one_site_coords = [((vec * lam) + self.coords[atom_index], q)]
+
+        return error, one_site_coords
+
+    def fit_two_sites(self, atom_index):
+        """
+        Fit method for two sites whose parent is <atom_index>
+        """
+        if len(self.molecule.atoms[atom_index].bonds) != 2:
+            error, site_coords = self.fit_two_sites_one_or_three_bonds(atom_index)
+        else:
+            error, site_coords = self.fit_two_sites_two_bonds(atom_index)
+
+        return error, site_coords
+
+    def fit_two_sites_one_or_three_bonds(self, atom_index):
+        """
+        Fit method for two sites whose parent, <atom_index> has one or three bonds
+        e.g. uncharged halogens and nitrogens
+        """
+        vec_a, vec_b = self.get_vector_from_coords(atom_index, n_sites=2)
+        bounds = ((-1.0, 1.0), (-1.0, 1.0), (-1.0, 1.0), (-1.0, 1.0))
+        if len(self.molecule.atoms[atom_index].bonds) == 1:
+            constraint = {
+                "type": "ineq",
+                "fun": VirtualSites.two_site_one_bond_constraint_charge,
+            }
+        else:
+            constraint = None
+        two_site_fit = minimize(
+            self.two_sites_objective_function,
+            np.array([0.0, 0.0, 1.0, 1.0]),
+            args=(atom_index, vec_a, vec_b),
+            bounds=bounds,
+            constraints=constraint,
+        )
+        error = two_site_fit.fun / len(self.sample_points)
+        q_a, q_b, lam_a, lam_b = two_site_fit.x
+        site_a_coords, site_b_coords = self.sites_coords_from_vecs_and_lams(
+            atom_index, lam_a, lam_b, vec_a, vec_b
+        )
+        two_site_coords = [
+            (site_a_coords, q_a),
+            (site_b_coords, q_b),
+        ]
+        return error, two_site_coords
+
+    def fit_two_sites_two_bonds(self, atom_index):
+        """
+        Fit method for two sites whose parent, <atom_index> has two bonds
+        e.g. uncharged oxygens
+        """
+        # Dummy error value to be overwritten
+        error = 10000
+        for alt in [True, False]:
+            bounds = ((-1.0, 1.0), (-1.0, 1.0), (-1.0, 1.0), (-1.0, 1.0))
+            vec_a, vec_b = self.get_vector_from_coords(atom_index, n_sites=2, alt=alt)
+            if self.molecule.enable_symmetry:
+                two_site_fit = minimize(
+                    self.symm_two_sites_objective_function,
+                    np.array([0.0, 1.0]),
+                    args=(atom_index, vec_a, vec_b),
+                    bounds=bounds[1:3],
+                    constraints={
+                        "type": "ineq",
+                        "fun": VirtualSites.two_site_two_bond_constraint,
+                    },
+                )
+                if (two_site_fit.fun / len(self.sample_points)) < error:
+                    error = two_site_fit.fun / len(self.sample_points)
+                    q, lam = two_site_fit.x
+                    q_a = q_b = q
+                    lam_a = lam_b = lam
+                    (
+                        site_a_coords,
+                        site_b_coords,
+                    ) = self.sites_coords_from_vecs_and_lams(
+                        atom_index, lam_a, lam_b, vec_a, vec_b
+                    )
+                    two_site_coords = [
+                        (site_a_coords, q_a),
+                        (site_b_coords, q_b),
+                    ]
+            else:
+                two_site_fit = minimize(
+                    self.two_sites_objective_function,
+                    np.array([0.0, 0.0, 1.0, 1.0]),
+                    args=(atom_index, vec_a, vec_b),
+                    bounds=bounds,
+                    constraints={
+                        "type": "ineq",
+                        "fun": VirtualSites.two_site_two_bond_constraint,
+                    },
+                )
+                if (two_site_fit.fun / len(self.sample_points)) < error:
+                    error = two_site_fit.fun / len(self.sample_points)
+                    q_a, q_b, lam_a, lam_b = two_site_fit.x
+                    (
+                        site_a_coords,
+                        site_b_coords,
+                    ) = self.sites_coords_from_vecs_and_lams(
+                        atom_index, lam_a, lam_b, vec_a, vec_b
+                    )
+                    two_site_coords = [
+                        (site_a_coords, q_a),
+                        (site_b_coords, q_b),
+                    ]
+        return error, two_site_coords
+
     def fit(self, atom_index: int):
         """
-        The error for the objective functionsis defined as the sum of differences at each sample point
+        The error for the objective functions is defined as the sum of differences at each sample point
         between the ideal ESP and the ESP with and without sites.
 
         * The ESP is first calculated without any virtual sites, if the error is below 1.0, no fitting
@@ -684,156 +793,70 @@ class VirtualSites:
         :param atom_index: The index of the atom being analysed.
         """
 
-        n_sample_points = len(self.no_site_esps)
-
-        # No site
+        # Calc error in esp when no sites are present
         vec = self.get_vector_from_coords(atom_index, n_sites=1)
         no_site_error = self.one_site_objective_function((0, 1), atom_index, vec)
-        self.site_errors[0] = no_site_error / n_sample_points
+        no_site_error /= len(self.sample_points)
 
-        if self.site_errors[0] <= 1.0:
+        # Error in esp is sufficiently low to not require virtual sites.
+        if no_site_error <= 1.0:
             return
 
-        # Bounds for fitting, format: charge, charge, lambda, lambda
-        # Since the vectors are scaled to be 1 angstrom long, lambda makes the v-site distance -1 to 1 angstrom.
-        bounds = ((-1.0, 1.0), (-1.0, 1.0), (-1.0, 1.0), (-1.0, 1.0))
+        one_site_error, one_site_coords = self.fit_one_site(atom_index)
 
-        # One site
-        one_site_fit = minimize(
-            self.one_site_objective_function,
-            np.array([0, 1]),
-            args=(atom_index, vec),
-            bounds=bounds[1:3],
-        )
-        self.site_errors[1] = one_site_fit.fun / n_sample_points
-        q, lam = one_site_fit.x
-        self.one_site_coords = [((vec * lam) + self.coords[atom_index], q, atom_index)]
+        two_site_error, two_site_coords = self.fit_two_sites(atom_index)
 
-        # 1 or 3 bonds
-        if len(self.molecule.atoms[atom_index].bonds) != 2:
-            vec_a, vec_b = self.get_vector_from_coords(atom_index, n_sites=2)
-            if len(self.molecule.atoms[atom_index].bonds) == 1:
-                constraint = {
-                    "type": "ineq",
-                    "fun": VirtualSites.two_site_one_bond_constraint_lambda,
-                }
-            else:
-                constraint = None
-            two_site_fit = minimize(
-                self.two_sites_objective_function,
-                np.array([0.0, 0.0, 1.0, 1.0]),
-                args=(atom_index, vec_a, vec_b),
-                bounds=bounds,
-                constraints=constraint,
-            )
-            self.site_errors[2] = two_site_fit.fun / n_sample_points
-            q_a, q_b, lam_a, lam_b = two_site_fit.x
-            site_a_coords, site_b_coords = self.sites_coords_from_vecs_and_lams(
-                atom_index, lam_a, lam_b, vec_a, vec_b
-            )
-            self.two_site_coords = [
-                (site_a_coords, q_a, atom_index),
-                (site_b_coords, q_b, atom_index),
-            ]
-
-        # 2 bonds
-        else:
-            # Arbitrarily large error; this will be overwritten.
-            final_err = 10000
-            for alt in [True, False]:
-                vec_a, vec_b = self.get_vector_from_coords(
-                    atom_index, n_sites=2, alt=alt
-                )
-                if self.molecule.enable_symmetry:
-                    two_site_fit = minimize(
-                        self.symm_two_sites_objective_function,
-                        np.array([0.0, 1.0]),
-                        args=(atom_index, vec_a, vec_b),
-                        bounds=bounds[1:3],
-                        constraints={
-                            "type": "ineq",
-                            "fun": VirtualSites.two_site_two_bond_constraint,
-                        },
-                    )
-                    if (two_site_fit.fun / n_sample_points) < final_err:
-                        final_err = two_site_fit.fun / n_sample_points
-                        self.site_errors[2] = two_site_fit.fun / n_sample_points
-                        q, lam = two_site_fit.x
-                        q_a = q_b = q
-                        lam_a = lam_b = lam
-                        (
-                            site_a_coords,
-                            site_b_coords,
-                        ) = self.sites_coords_from_vecs_and_lams(
-                            atom_index, lam_a, lam_b, vec_a, vec_b
-                        )
-                        self.two_site_coords = [
-                            (site_a_coords, q_a, atom_index),
-                            (site_b_coords, q_b, atom_index),
-                        ]
-                else:
-                    two_site_fit = minimize(
-                        self.two_sites_objective_function,
-                        np.array([0.0, 0.0, 1.0, 1.0]),
-                        args=(atom_index, vec_a, vec_b),
-                        bounds=bounds,
-                    )
-                    if (two_site_fit.fun / n_sample_points) < final_err:
-                        final_err = two_site_fit.fun / n_sample_points
-                        self.site_errors[2] = two_site_fit.fun / n_sample_points
-                        q_a, q_b, lam_a, lam_b = two_site_fit.x
-                        (
-                            site_a_coords,
-                            site_b_coords,
-                        ) = self.sites_coords_from_vecs_and_lams(
-                            atom_index, lam_a, lam_b, vec_a, vec_b
-                        )
-                        self.two_site_coords = [
-                            (site_a_coords, q_a, atom_index),
-                            (site_b_coords, q_b, atom_index),
-                        ]
+        site_errors = {
+            0: no_site_error,
+            1: one_site_error,
+            2: two_site_error,
+        }
 
         max_err = self.molecule.v_site_error_factor
-        if self.site_errors[0] < min(
-            self.site_errors[1] * max_err, self.site_errors[2] * max_err
-        ):
+        if no_site_error < min(one_site_error * max_err, two_site_error * max_err):
             append_to_log(
                 self.molecule.home,
                 "No virtual site placement has reduced the error significantly.",
                 and_print=True,
             )
-        elif self.site_errors[1] < self.site_errors[2] * max_err:
+        elif one_site_error < two_site_error * max_err:
             append_to_log(
                 self.molecule.home,
                 "The addition of one virtual site was found to be best.",
                 and_print=True,
             )
-            self.v_sites_coords.extend(self.one_site_coords)
-            self.molecule.NonbondedForce[atom_index][0] -= self.one_site_coords[0][1]
-            self.molecule.ddec_data[atom_index].charge -= self.one_site_coords[0][1]
+            self.v_sites_coords.extend((*one_site_coords, atom_index))
+            self.molecule.NonbondedForce[atom_index][0] -= one_site_coords[0][1]
+            self.molecule.ddec_data[atom_index].charge -= one_site_coords[0][1]
         else:
             append_to_log(
                 self.molecule.home,
                 "The addition of two virtual sites was found to be best.",
                 and_print=True,
             )
-            self.v_sites_coords.extend(self.two_site_coords)
+            self.v_sites_coords.extend((*two_site_coords, atom_index))
             self.molecule.NonbondedForce[atom_index][0] -= (
-                self.two_site_coords[0][1] + self.two_site_coords[1][1]
+                two_site_coords[0][1] + two_site_coords[1][1]
             )
             self.molecule.ddec_data[atom_index].charge -= (
-                self.two_site_coords[0][1] + self.two_site_coords[1][1]
+                two_site_coords[0][1] + two_site_coords[1][1]
             )
         append_to_log(
             self.molecule.home,
             f"Errors (kcal/mol):\n"
             f"No Site     One Site     Two Sites\n"
-            f"{self.site_errors[0]:.4f}      {self.site_errors[1]:.4f}       {self.site_errors[2]:.4f}",
+            f"{no_site_error:.4f}      {one_site_error:.4f}       {two_site_error:.4f}",
             and_print=True,
         )
-        self.plot(atom_index)
+        self.plot(atom_index, site_errors, one_site_coords, two_site_coords)
 
-    def plot(self, atom_index: int):
+    def plot(
+        self,
+        atom_index: int,
+        errors: Dict,
+        one_site_coords: List[Tuple[np.ndarray, float]],
+        two_site_coords: List[Tuple[np.ndarray, float]],
+    ):
         """
         Figure with three subplots.
         All plots show the atoms and bonds as balls and sticks; virtual sites are x's; sample points are dots.
@@ -844,7 +867,6 @@ class VirtualSites:
         """
 
         fig = plt.figure(figsize=plt.figaspect(0.33), tight_layout=True)
-        # fig.suptitle('Virtual Site Placements', fontsize=20)
 
         norm = plt.Normalize(vmin=-1.0, vmax=1.0)
         cmap = "cool"
@@ -858,7 +880,9 @@ class VirtualSites:
         # List of tuples where each tuple is the xyz atom coords, followed by their partial charge
         atom_points = [
             (coord, atom_data[0])  # [((x, y, z), q), ... ]
-            for coord, atom_data in zip(self.coords, self.molecule.NonbondedForce)
+            for coord, atom_data in zip(
+                self.coords, self.molecule.NonbondedForce.values()
+            )
         ]
 
         # Add atom positions to all subplots
@@ -902,35 +926,33 @@ class VirtualSites:
             marker="o",
             s=5,
         )
-        samp_plt.title.set_text(
-            f"Sample Points Positions\nError: {self.site_errors[0]: .5}"
-        )
+        samp_plt.title.set_text(f"Sample Points Positions\nError: {errors[0]: .5}")
 
         # Centre subplot contains the single v-site
         one_plt.scatter(
-            xs=[i[0][0] for i in self.one_site_coords],
-            ys=[i[0][1] for i in self.one_site_coords],
-            zs=[i[0][2] for i in self.one_site_coords],
-            c=[i[1] for i in self.one_site_coords],
+            xs=[i[0][0] for i in one_site_coords],
+            ys=[i[0][1] for i in one_site_coords],
+            zs=[i[0][2] for i in one_site_coords],
+            c=[i[1] for i in one_site_coords],
             marker="x",
             s=200,
             cmap=cmap,
             norm=norm,
         )
-        one_plt.title.set_text(f"One Site Position\nError: {self.site_errors[1]: .5}")
+        one_plt.title.set_text(f"One Site Position\nError: {errors[1]: .5}")
 
         # Right subplot contains the two v-sites
         two_plt.scatter(
-            xs=[i[0][0] for i in self.two_site_coords],
-            ys=[i[0][1] for i in self.two_site_coords],
-            zs=[i[0][2] for i in self.two_site_coords],
-            c=[i[1] for i in self.two_site_coords],
+            xs=[i[0][0] for i in two_site_coords],
+            ys=[i[0][1] for i in two_site_coords],
+            zs=[i[0][2] for i in two_site_coords],
+            c=[i[1] for i in two_site_coords],
             marker="x",
             s=200,
             cmap=cmap,
             norm=norm,
         )
-        two_plt.title.set_text(f"Two Sites Positions\nError: {self.site_errors[2]: .5}")
+        two_plt.title.set_text(f"Two Sites Positions\nError: {errors[2]: .5}")
 
         sm = ScalarMappable(norm=norm, cmap=cmap)
         sm.set_array([])

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you do, please make sure Gaussian09 is executable with the command `g09`.
 * [Chargemol](https://sourceforge.net/projects/ddec/files/)
 
 Chargemol can be downloaded and installed from a zip file in the above link. 
-Be sure to add the path to the QUBEKit configs once you've generated them *([explanation](https://github.com/qubekit/QUBEKit#before-you-start-config-files))*.
+Be sure to add the chargemol path to the QUBEKit config files.
 
 Most conda packages are included in the conda-forge install.
 Packages not available through conda-forge may need to be installed separately.
@@ -212,13 +212,13 @@ you may use whatever case you like for the name of files (e.g. `-i DMSO.pdb`) or
 [Cook Book](https://github.com/qubekit/QUBEKit#cook-book) section. 
 This section covers some simple examples*
 
-Running a full analysis on `molecule.pdb` with a non-default charge of `1`, the default charge engine `Chargemol` and with GeomeTRIC `off`:
+Running a full analysis on `molecule.pdb` with a non-default charge of `1`, the default charge engine `Chargemol` and with virtual sites `disabled`:
 Note, ordering does not matter as long as tuples commands (`-c` `1`) are together.
 
-`-i` is for the input, `-c` denotes the charge and `-geo` is for (en/dis)abling geomeTRIC.
+`-i` is for the input, `-c` denotes the charge and `-sites` is for (en/dis)abling virtual site fitting.
     
-    QUBEKit -i molecule.pdb -c 1 -geo false
-    QUBEKit -c 1 -geo false -i molecule.pdb
+    QUBEKit -i molecule.pdb -c 1 -sites false
+    QUBEKit -c 1 -sites false -i molecule.pdb
 
 Running a full analysis with a non-default bonds engine: Gaussian09 (g09):
 
@@ -477,7 +477,6 @@ All commands can be viewed by calling `QUBEKit -h`. Below is an explanation of w
 
 | Command | Type | Description |
 | --- | --- | --- |
-| `-geo` | Bool: `True`, `true`, `t`, `False`, `false`, `f` | Enable or disable GeomeTRIC |
 | `-ddec` | Int: `3`, `6` | Change DDEC version |
 | `-solvent` | Bool | Enable or disable the solvent model |
 | `-param` | String: `antechamber`, `openff`, `xml`  | Change the method for initial parametrisation |


### PR DESCRIPTION
## Description
Rotatable bonds changed to use smirks patterns and removed refs to -geo in README

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] Molecule method which finds rotatable bonds.
  - [X] Option to supply different smirks patterns.
  - [X] Tests (removed old ones, added new ones).
  - [X] Removed references to -geo command, since it has been removed from QUBEKit.
  - [X] Rewritten fit() method of v-sites, and somewhat refactored plotting.
  - [ ] Further rework v-sites. Move away from lists of esps and consider breaking up into two classes: one for general maths, one for per-atom fitting.

## Questions
- [ ] Are there other functional groups we want to exclude from rotatable bonds?

## Status
- [X] Ready to go