### PR TITLE
More Improper torsion tests.

### DIFF
--- a/qubekit/engines/base_engine.py
+++ b/qubekit/engines/base_engine.py
@@ -41,17 +41,6 @@ class BaseEngine(BaseModel):
             },
         }
 
-    @validator("cores", "memory")
-    def validate_resource(cls, resource: int) -> int:
-        """
-        Make sure that the resource is even to make distribution easier.
-        """
-        if resource % 2 != 0 and resource != 1:
-            raise ValueError(
-                f"The resource must be even to make distribution between parallel workers easier."
-            )
-        return resource
-
     @validator("program")
     def validate_program(cls, program: str) -> str:
         """

--- a/qubekit/engines/torsiondrive.py
+++ b/qubekit/engines/torsiondrive.py
@@ -20,9 +20,11 @@ from qubekit.utils.helpers import export_torsiondrive_data
 class TorsionDriver(BaseEngine):
 
     type: Literal["torsiondriver"] = "torsiondriver"
-    n_workers: Literal[1, 2, 4] = Field(
+    n_workers: int = Field(
         1,
         description="The number of workers that should be used to run parallel optimisations. Note the threads and memory will be divided between workers.",
+        ge=1,
+        le=4,
     )
     grid_spacing: int = Field(
         15, description="The grid spacing in degrees between each optimisation."
@@ -239,8 +241,9 @@ class TorsionDriver(BaseEngine):
             cores = self.cores
             memory = self.memory
         else:
-            cores = self.cores / self.n_workers
-            memory = self.memory / self.n_workers
+            # always round down to get an even distribution of cores and memory
+            cores = int(self.cores / self.n_workers)
+            memory = int(self.memory / self.n_workers)
 
         geom = GeometryOptimiser(
             program=self.program,

--- a/qubekit/tests/engines/qcengine_test.py
+++ b/qubekit/tests/engines/qcengine_test.py
@@ -40,13 +40,3 @@ def test_single_point_energy(program, basis, method, tmpdir):
         assert result.model.basis == basis
         assert result.model.method == method
         assert result.provenance.creator.lower() == program
-
-
-def test_odd_resource():
-    """
-    Make sure an error is raised if we pass an odd amount of resource as this
-    makes it harder to divide between workers.
-    """
-
-    with pytest.raises(ValueError):
-        _ = QCEngine(cores=3)

--- a/qubekit/tests/ligand/parametrisation_test.py
+++ b/qubekit/tests/ligand/parametrisation_test.py
@@ -128,15 +128,15 @@ def test_parameter_round_trip(method, tmpdir, xml, openff, antechamber):
                 if key != "atoms":
                     assert getattr(terms, key) == pytest.approx(getattr(other_dih, key))
 
-                    
-def test_improper_round_trip_openff(tmpdir):
+
+def test_improper_round_trip_openff(tmpdir, openff):
     """
     Make sure that improper torsions are correctly round tripped.
     """
     with tmpdir.as_cwd():
         mol = Ligand.from_file(get_data("benzene.sdf"))
         # assign new parameters
-        OpenFF().parametrise_molecule(molecule=mol)
+        openff.parametrise_molecule(molecule=mol)
         # make sure we have some 18 impropers
         assert mol.ImproperTorsionForce.n_parameters == 18
         # now write out the parameters
@@ -149,14 +149,14 @@ def test_improper_round_trip_openff(tmpdir):
         assert mol2.ImproperTorsionForce.n_parameters == 18
 
 
-def test_improper_round_trip_antechamber(tmpdir):
+def test_improper_round_trip_antechamber(tmpdir, antechamber):
     """
     Make sure that improper torsions are correctly round tripped.
     """
     with tmpdir.as_cwd():
         mol = Ligand.from_file(get_data("benzene.sdf"))
         # assign new parameters
-        AnteChamber().parametrise_molecule(molecule=mol)
+        antechamber.parametrise_molecule(molecule=mol)
         # make sure we have some 6 impropers
         assert mol.ImproperTorsionForce.n_parameters == 6
         # now write out the parameters

--- a/qubekit/tests/ligand/parametrisation_test.py
+++ b/qubekit/tests/ligand/parametrisation_test.py
@@ -128,6 +128,46 @@ def test_parameter_round_trip(method, tmpdir, xml, openff, antechamber):
                 if key != "atoms":
                     assert getattr(terms, key) == pytest.approx(getattr(other_dih, key))
 
+                    
+def test_improper_round_trip_openff(tmpdir):
+    """
+    Make sure that improper torsions are correctly round tripped.
+    """
+    with tmpdir.as_cwd():
+        mol = Ligand.from_file(get_data("benzene.sdf"))
+        # assign new parameters
+        OpenFF().parametrise_molecule(molecule=mol)
+        # make sure we have some 18 impropers
+        assert mol.ImproperTorsionForce.n_parameters == 18
+        # now write out the parameters
+        mol.write_parameters(file_name="test.xml")
+        # now load a new molecule
+        mol2 = Ligand.from_file(get_data("benzene.sdf"))
+        assert mol2.TorsionForce.n_parameters == 0
+        XML().parametrise_molecule(molecule=mol2, input_files=["test.xml"])
+        # make sure we have the same 18 impropers
+        assert mol2.ImproperTorsionForce.n_parameters == 18
+
+
+def test_improper_round_trip_antechamber(tmpdir):
+    """
+    Make sure that improper torsions are correctly round tripped.
+    """
+    with tmpdir.as_cwd():
+        mol = Ligand.from_file(get_data("benzene.sdf"))
+        # assign new parameters
+        AnteChamber().parametrise_molecule(molecule=mol)
+        # make sure we have some 6 impropers
+        assert mol.ImproperTorsionForce.n_parameters == 6
+        # now write out the parameters
+        mol.write_parameters(file_name="test.xml")
+        # now load a new molecule
+        mol2 = Ligand.from_file(get_data("benzene.sdf"))
+        assert mol2.TorsionForce.n_parameters == 0
+        XML().parametrise_molecule(molecule=mol2, input_files=["test.xml"])
+        # make sure we have the same 18 impropers
+        assert mol2.ImproperTorsionForce.n_parameters == 6
+
 
 def test_xml_with_sites(tmpdir, xml):
     """


### PR DESCRIPTION
## Description
This PR adds some more tests for improper torsions to make sure none are lost when round-tripping to file after parameterization. This extends the last test as the number of improper torsions is explicitly checked rather than the total energy as they may not contribute much when relaxed.

## Status
- [X] Ready to go