### PR TITLE
TorsionDrive scratch fix

### DIFF
--- a/qubekit/molecules/components.py
+++ b/qubekit/molecules/components.py
@@ -324,6 +324,7 @@ class ReferenceData(BaseModel):
 
     class Config:
         validate_assignment = True
+        json_encoders = {np.ndarray: lambda v: v.flatten().tolist()}
 
     @validator("geometry", "gradient")
     def _check_geom_grad(cls, array: np.ndarray) -> np.array:
@@ -368,6 +369,7 @@ class TorsionDriveData(BaseModel):
     class Config:
         validate_assignment = True
         allow_mutation = False
+        json_encoders = {np.ndarray: lambda v: v.flatten().tolist()}
 
     @validator("torsion_drive_range")
     def _check_scan_range(cls, scan_range: Tuple[int, int]) -> Tuple[int, int]:
@@ -375,6 +377,13 @@ class TorsionDriveData(BaseModel):
         Make sure the scan range is in order lowest to highest.
         """
         return tuple(sorted(scan_range))
+
+    def to_file(self, file_name: str) -> None:
+        """
+        Write the object to file.
+        """
+        with open(file_name, "w") as output:
+            output.write(self.json(indent=2))
 
     @property
     def max_angle(self) -> int:

--- a/qubekit/tests/engines/torsiondrive_test.py
+++ b/qubekit/tests/engines/torsiondrive_test.py
@@ -78,6 +78,7 @@ def test_optimise_grid_point_and_update(tmpdir, ethane_state):
             coordinates=coords,
             dihedral=ethane_state["dihedrals"][0],
             dihedral_angle=-60,
+            job_id=0,
         )
         new_state = tdriver._update_state(
             td_state=ethane_state,


### PR DESCRIPTION
## Description
This PR makes the scratch folders in the torsiondrive engine have a unique job id to ensure they are not shared between QM processes. The folders are now also removed once the torsiondrive is complete and a minimal number of files are saved which encode the whole torsiondrive.


## Status
- [ ] Ready to go