### PR TITLE
Torsion symmetry update.

### DIFF
--- a/qubekit/forcefield/parameters.py
+++ b/qubekit/forcefield/parameters.py
@@ -21,6 +21,10 @@ class BasicParameterModel(BaseModel, abc.ABC):
         set(),
         description="Any cosmetic attributes which should be added to the xml such as tagging parameters for fitting with ForceBalance.",
     )
+    parameter_eval: Set[str] = Field(
+        set(),
+        description="A list of parameter eval tags that should be added to the xml to constrain parameters.",
+    )
 
     class Config:
         validate_assignment = True
@@ -66,7 +70,7 @@ class BaseParameter(BasicParameterModel):
 
     def xml_data(self) -> Dict[str, str]:
         """Get the xml data for this parameter in the correct format."""
-        data = self.dict(exclude={"atoms", "attributes", "type"})
+        data = self.dict(exclude={"atoms", "attributes", "type", "parameter_eval"})
         # we need to string everything
         for key, value in data.items():
             if value == "pi":
@@ -78,8 +82,11 @@ class BaseParameter(BasicParameterModel):
         attribute_string = ", ".join(
             attribute for attribute in self.attributes if self.attributes
         )
+        eval_string = ", ".join(param_eval for param_eval in self.parameter_eval)
         if attribute_string:
             data["parameterize"] = attribute_string
+        if eval_string:
+            data["parameter_eval"] = eval_string
         # now do class tags
         for i, atom in enumerate(self.atoms, start=1):
             data[f"class{i}"] = str(atom)

--- a/qubekit/tests/conftest.py
+++ b/qubekit/tests/conftest.py
@@ -5,7 +5,7 @@ from qubekit.parametrisation import XML, AnteChamber, OpenFF
 from qubekit.utils.file_handling import get_data
 
 
-@pytest.fixture
+@pytest.fixture()
 def acetone():
     """
     Make a ligand class from the acetone pdb.
@@ -13,27 +13,32 @@ def acetone():
     return Ligand.from_file(file_name=get_data("acetone.sdf"))
 
 
-@pytest.fixture
+@pytest.fixture()
 def water():
     """Make a qube water molecule."""
     return Ligand.from_file(file_name=get_data("water.pdb"))
 
 
-@pytest.fixture
+@pytest.fixture()
 def antechamber():
     return AnteChamber(force_field="gaff2")
 
 
-@pytest.fixture
+@pytest.fixture()
 def openff():
     return OpenFF(force_field="openff_unconstrained-1.3.0.offxml")
 
 
-@pytest.fixture
+@pytest.fixture()
 def xml():
     return XML()
 
 
-@pytest.fixture
+@pytest.fixture()
 def coumarin():
     return Ligand.parse_file(get_data("coumarin_hess_wbo.json"))
+
+
+@pytest.fixture()
+def mol_47():
+    return Ligand.from_smiles("CC(C)(O)CCC(C)(C)O", "mol_47")

--- a/qubekit/tests/torsions/test_scan.py
+++ b/qubekit/tests/torsions/test_scan.py
@@ -150,3 +150,16 @@ def test_double_dihedral(tmpdir):
         assert len(result_mol.qm_scans) == 2
         # make sure input molecule coords were not changed
         assert np.allclose(mol.coordinates, result_mol.coordinates)
+
+
+def test_symmetry_deduplication(tmpdir, mol_47):
+    """Make sure only one torsion per symmetry group is found."""
+
+    scanner = TorsionScan1D()
+    # get all rotatable bonds
+    smirks = [torsion.smirks for torsion in scanner.avoided_torsions]
+    bonds = mol_47.find_rotatable_bonds(smirks_to_remove=smirks)
+    assert len(bonds) == 5
+    # now deduplicate for symmetry
+    bonds = scanner._get_symmetry_unique_bonds(mol_47, bonds)
+    assert len(bonds) == 3

--- a/qubekit/torsions/scanning/torsion_scanner.py
+++ b/qubekit/torsions/scanning/torsion_scanner.py
@@ -101,6 +101,9 @@ class TorsionScan1D(StageBase):
             print("No rotatable bonds found to scan!")
             return molecule
 
+        # remove symmetry duplicates
+        bonds = self._get_symmetry_unique_bonds(molecule=drive_mol, bonds=bonds)
+
         torsion_scans = []
         for bond in bonds:
             # get the scan range and a torsion for the bond
@@ -119,6 +122,20 @@ class TorsionScan1D(StageBase):
         # make sure we have all of the scans we expect
         assert len(result_mol.qm_scans) == len(bonds)
         return result_mol
+
+    def _get_symmetry_unique_bonds(
+        self, molecule: "Ligand", bonds: List["Bond"]
+    ) -> List["Bond"]:
+        """
+        For a list of central torsion bonds deduplicate the list by bond symmetry types.
+        """
+        atom_types = molecule.atom_types
+        unique_bonds = {}
+        for bond in bonds:
+            bond_type = f"{atom_types[bond.atom1_index]}-{atom_types[bond.atom2_index]}"
+            if bond_type not in unique_bonds and bond_type[::-1] not in unique_bonds:
+                unique_bonds[bond_type] = bond
+        return list(unique_bonds.values())
 
     def _get_scan_range(self, molecule: "Ligand", bond: "Bond") -> Tuple[int, int]:
         """


### PR DESCRIPTION
## Description
This PR allows qubekit to deduplicate torsion scans by torsion symmetry, this should lead to less torsion drives. Torsion symmetry is also used during fitting, here like torsions are linked together using parameter eval tags which should lead to faster fitting as the gradients of fewer parameters are required. The default fitting convergence criteria has also been relaxed slightly. 


## Status
- [X] Ready to go