### PR TITLE
Vsite default LJ parameters

### DIFF
--- a/qubekit/molecules/ligand.py
+++ b/qubekit/molecules/ligand.py
@@ -739,7 +739,7 @@ class Molecule(SchemaBase):
                 attrib={
                     "charge": str(site.charge),
                     "epsilon": "0",
-                    "sigma": "0",
+                    "sigma": "1",
                     "type": site_name,
                 },
             )


### PR DESCRIPTION
## Description
This PR updates the vsite default LJ parameters to be `sigma=1` `epsilon=0` to make sure long-range corrections work when using a custom nonbonded force in opemmm during alchemical calculations.

## Status
- [X] Ready to go