### PR TITLE
Save all torsion values 

### DIFF
--- a/qubekit/parametrisation/base_parametrisation.py
+++ b/qubekit/parametrisation/base_parametrisation.py
@@ -169,9 +169,6 @@ class Parametrisation(StageBase, abc.ABC):
             if "PeriodicTorsionForce" in forces:
                 for Torsion in forces["PeriodicTorsionForce"].iter("Torsion"):
                     k = float(Torsion.get("k"))
-                    # if k=0 there is no value in saving
-                    if k == 0:
-                        continue
                     tor_str = tuple(int(Torsion.get(f"p{i}")) for i in range(1, 5))
                     phase = float(Torsion.get("phase"))
                     if phase == 3.141594:

--- a/qubekit/tests/ligand/parametrisation_test.py
+++ b/qubekit/tests/ligand/parametrisation_test.py
@@ -132,7 +132,10 @@ def test_parameter_round_trip(method, tmpdir, xml, openff, antechamber):
             for key in dihedral.__fields__:
                 # openmm will not load any torsions which have k=0, this causes differences between antechamber and
                 # qubekit when the phase is not as expected, this does not change the energy however as k=0
-                if key not in ["atoms", "attributes", "parameter_eval"] and "phase" not in key:
+                if (
+                    key not in ["atoms", "attributes", "parameter_eval"]
+                    and "phase" not in key
+                ):
                     assert getattr(dihedral, key) == pytest.approx(
                         getattr(other_dih, key)
                     )

--- a/qubekit/tests/ligand/parametrisation_test.py
+++ b/qubekit/tests/ligand/parametrisation_test.py
@@ -68,6 +68,12 @@ def test_openff_skeleton(tmpdir, openff):
         # no charges should be generated
         for i in range(mol.n_atoms):
             assert mol.NonbondedForce[(0,)].charge == 0
+        # make sure dummy torsions are kept
+        boron_torsion = mol.TorsionForce[(1, 0, 8, 7)]
+        assert boron_torsion.k1 == 0
+        assert boron_torsion.k2 == 0
+        assert boron_torsion.k3 == 0
+        assert boron_torsion.k4 == 0
 
 
 @pytest.mark.parametrize(

--- a/qubekit/tests/ligand/parametrisation_test.py
+++ b/qubekit/tests/ligand/parametrisation_test.py
@@ -130,7 +130,9 @@ def test_parameter_round_trip(method, tmpdir, xml, openff, antechamber):
         for dihedral in param_mol2.TorsionForce.parameters:
             other_dih = param_mol.TorsionForce[dihedral.atoms]
             for key in dihedral.__fields__:
-                if key not in ["atoms", "attributes", "parameter_eval"]:
+                # openmm will not load any torsions which have k=0, this causes differences between antechamber and
+                # qubekit when the phase is not as expected, this does not change the energy however as k=0
+                if key not in ["atoms", "attributes", "parameter_eval"] and "phase" not in key:
                     assert getattr(dihedral, key) == pytest.approx(
                         getattr(other_dih, key)
                     )


### PR DESCRIPTION
## Description
All torsion values from the initial parameterisation are now saved, this fixes a bug where dummy values were dropped when trying to parameterise a molecule with missing coverage in the base force field. 


## Status
- [ ] Ready to go