### PR TITLE
Fix missing alpha and beta when combining xmls

### DIFF
--- a/qubekit/cli/combine.py
+++ b/qubekit/cli/combine.py
@@ -273,6 +273,8 @@ def _combine_molecules(
                     atom=atom,
                     rfree_data=rfree_data[rfree_code],
                     a_and_b=fit_ab,
+                    alpha_ref=rfree_data["alpha"],
+                    beta_ref=rfree_data["beta"],
                     rfree_code=rfree_code if rfree_code in parameters else None,
                 )
                 atom_data["parameter_eval"] = eval_string
@@ -322,6 +324,8 @@ def _get_eval_string(
     atom: "Atom",
     rfree_data: Dict[str, str],
     a_and_b: bool,
+    alpha_ref: str,
+    beta_ref: str,
     rfree_code: Optional[str] = None,
 ) -> str:
     """
@@ -329,17 +333,17 @@ def _get_eval_string(
     """
 
     if a_and_b:
-        alpha = "PARM['xalpha/alpha']*"
-        beta = f"*({atom.aim.volume}/{rfree_data['v_free']})**PARM['xbeta/beta']"
+        alpha = "PARM['xalpha/alpha']"
+        beta = "PARM['xbeta/beta']"
     else:
-        alpha, beta = "", ""
+        alpha, beta = alpha_ref, beta_ref
     if rfree_code is not None:
         rfree = f"PARM['{rfree_code}Element/{rfree_code.lower()}free']"
     else:
         rfree = f"{rfree_data['r_free']}"
 
     eval_string = (
-        f"epsilon=({alpha}{rfree_data['b_free']}{beta})/(128*{rfree}**6)*{constants.EPSILON_CONVERSION}, "
+        f"epsilon=({alpha}*{rfree_data['b_free']}*({atom.aim.volume}/{rfree_data['v_free']})**{beta})/(128*{rfree}**6)*{constants.EPSILON_CONVERSION}, "
         f"sigma=2**(5/6)*({atom.aim.volume}/{rfree_data['v_free']})**(1/3)*{rfree}*{constants.SIGMA_CONVERSION}"
     )
 

--- a/qubekit/tests/cli/test_combine.py
+++ b/qubekit/tests/cli/test_combine.py
@@ -91,7 +91,7 @@ def test_find_molecules_and_rfree(acetone, tmpdir, rdkit_workflow):
             1,
             False,
             "C",
-            f"epsilon=(46.6)/(128*PARM['CElement/cfree']**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*PARM['CElement/cfree']*{constants.SIGMA_CONVERSION}",
+            f"epsilon=(1.32*46.6*(21.129491/34.4)**0.469)/(128*PARM['CElement/cfree']**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*PARM['CElement/cfree']*{constants.SIGMA_CONVERSION}",
             id="No AB Rfree",
         ),
         pytest.param(
@@ -105,7 +105,7 @@ def test_find_molecules_and_rfree(acetone, tmpdir, rdkit_workflow):
             1,
             False,
             None,
-            f"epsilon=(46.6)/(128*2**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*2*{constants.SIGMA_CONVERSION}",
+            f"epsilon=(1.32*46.6*(21.129491/34.4)**0.469)/(128*2**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*2*{constants.SIGMA_CONVERSION}",
             id="No AB No Rfree",
         ),
     ],
@@ -121,8 +121,10 @@ def test_get_eval_string(atom, a_and_b, rfree_code, expected, coumarin):
         rfree_data=rfree_data,
         a_and_b=a_and_b,
         rfree_code=rfree_code,
+        alpha_ref="1.32",
+        beta_ref="0.469",
     )
-    assert eval_string == expected
+    assert eval_string == expected, print(eval_string)
 
 
 def test_combine_molecules_deepdiff(acetone, openff, coumarin, tmpdir, rfree_data):


### PR DESCRIPTION
## Description
This PR fixes the xml combiner CLI command to include the alpha and beta scaling when not fitting alpha and beta which was missed previously. This would cause the parameter eval tags to be incorrect and give inconsistent sigma and epsilon values compared to those calculated by qubekit directly. 


## Status
- [x] Ready to go