### PR TITLE
Vsite distance regularisation

### DIFF
--- a/qubekit/nonbonded/virtual_sites.py
+++ b/qubekit/nonbonded/virtual_sites.py
@@ -62,6 +62,10 @@ class VirtualSites(StageBase):
         1.0, description="The ESP error threshold to start fitting virtual sites.", gt=0
     )
 
+    regularisation_epsilon: float = Field(
+        0.0, description="The regularisation factor of the distance between the virtual site to the parent atom."
+    )
+
     # only for debugging so not exposed
     _enable_symmetry: bool = PrivateAttr(default=True)
 
@@ -645,7 +649,9 @@ class VirtualSites(StageBase):
         return the sum of differences at each sample point between the ideal ESP and the calculated ESP.
         """
         site_esps = self._esp_from_lambda_and_charge(atom_index, *q_lam, vec)
-        return sum(abs(self._no_site_esps - site_esps))
+        mean_abs_diff = np.mean(abs(self._no_site_esps - site_esps))
+        regularisation = abs(q_lam[1]) * self.regularisation_epsilon
+        return mean_abs_diff + regularisation
 
     def _two_sites_objective_function(
         self,
@@ -661,7 +667,9 @@ class VirtualSites(StageBase):
         site_esps = self._esp_from_lambdas_and_charges(
             atom_index, *qa_qb_lama_lamb, vec_a, vec_b
         )
-        return sum(abs(self._no_site_esps - site_esps))
+        mean_abs_diff = np.mean(abs(self._no_site_esps - site_esps))
+        regularisation = np.mean(abs(qa_qb_lama_lamb[2:])) * self.regularisation_epsilon
+        return mean_abs_diff + regularisation
 
     def _symm_two_sites_objective_function(
         self,
@@ -678,7 +686,9 @@ class VirtualSites(StageBase):
         site_esps = self._symm_esp_from_lambdas_and_charges(
             atom_index, *q_lam, vec_a, vec_b
         )
-        return sum(abs(self._no_site_esps - site_esps))
+        mean_abs_diff = np.mean(abs(self._no_site_esps - site_esps))
+        regularisation = abs(q_lam[1]) * self.regularisation_epsilon
+        return mean_abs_diff + regularisation
 
     @staticmethod
     def _two_site_one_or_three_bond_constraint_charge(x):
@@ -732,8 +742,9 @@ class VirtualSites(StageBase):
             args=(atom_index, vec),
             bounds=bounds,
         )
-        error = one_site_fit.fun / len(self._sample_points)
+        error = one_site_fit.fun
         q, lam = one_site_fit.x
+        print(f'1 VS, lam q error: {lam} {q} {error}')
         one_site_coords = [((vec * lam) + self._coords[atom_index], q, atom_index)]
 
         return error, one_site_coords
@@ -779,8 +790,8 @@ class VirtualSites(StageBase):
                 bounds=bounds,
                 constraints=constraint,
             )
-            if two_site_fit.fun / len(self._sample_points) < error:
-                error = two_site_fit.fun / len(self._sample_points)
+            if two_site_fit.fun < error:
+                error = two_site_fit.fun
 
                 q_a, q_b, lam_a, lam_b = two_site_fit.x
                 site_a_coords, site_b_coords = self._sites_coords_from_vecs_and_lams(
@@ -815,9 +826,10 @@ class VirtualSites(StageBase):
                         "fun": VirtualSites._symm_two_site_two_bond_constraint,
                     },
                 )
-                if (two_site_fit.fun / len(self._sample_points)) < error:
-                    error = two_site_fit.fun / len(self._sample_points)
+                if two_site_fit.fun < error:
+                    error = two_site_fit.fun
                     q, lam = two_site_fit.x
+                    print(f'Symmetric 2 VS lam q error {lam} {q} {error}')
                     q_a = q_b = q
                     lam_a = lam_b = lam
                     (
@@ -841,9 +853,10 @@ class VirtualSites(StageBase):
                         "fun": VirtualSites._two_site_two_bond_constraint,
                     },
                 )
-                if (two_site_fit.fun / len(self._sample_points)) < error:
-                    error = two_site_fit.fun / len(self._sample_points)
+                if two_site_fit.fun < error:
+                    error = two_site_fit.fun
                     q_a, q_b, lam_a, lam_b = two_site_fit.x
+                    print(f'2 VS: lama lamb q_a q_b error: {lam_a} {lam_b} {q_a} {q_b} {error}')
                     (
                         site_a_coords,
                         site_b_coords,
@@ -874,8 +887,7 @@ class VirtualSites(StageBase):
 
         # Calc error in esp when no sites are present
         vec = self._get_vector_from_coords(atom_index, n_sites=1)
-        no_site_error = self._one_site_objective_function((0, 1), atom_index, vec)
-        no_site_error /= len(self._sample_points)
+        no_site_error = self._one_site_objective_function((0, 0), atom_index, vec)
 
         # Error in esp is sufficiently low to not require virtual sites.
         if no_site_error <= self.site_error_threshold:

--- a/qubekit/nonbonded/virtual_sites.py
+++ b/qubekit/nonbonded/virtual_sites.py
@@ -67,7 +67,8 @@ class VirtualSites(StageBase):
     )
 
     regularisation_epsilon: float = Field(
-        0.0, description="The regularisation constrining the distance between the virtual site to the parent atom."
+        0.0,
+        description="The regularisation constraining the distance between the virtual site to the parent atom.",
     )
 
     # only for debugging so not exposed
@@ -719,7 +720,7 @@ class VirtualSites(StageBase):
         site_esps = self._symm_esp_from_lambdas_and_charges(
             atom_index, *q_lama, vec_a, vec_b
         )
-        mean_abs_diff = np.mean(np.abs(self._no_site_esps - site_esps))
+        mean_abs_diff = np.mean(abs(self._no_site_esps - site_esps))
         regularisation = abs(q_lama[1]) * self.regularisation_epsilon
         return mean_abs_diff + regularisation
 
@@ -796,7 +797,6 @@ class VirtualSites(StageBase):
         )
         error = one_site_fit.fun
         q, lam = one_site_fit.x
-        print(f'1 VS, lam q error: {lam} {q} {error}')
         one_site_coords = [((vec * lam) + self._coords[atom_index], q, atom_index)]
 
         return error, one_site_coords
@@ -882,7 +882,6 @@ class VirtualSites(StageBase):
                 if two_site_fit.fun < error:
                     error = two_site_fit.fun
                     q, lam = two_site_fit.x
-                    print(f'Symmetric 2 VS lam q error {lam} {q} {error}')
                     q_a = q_b = q
                     lam_a = lam_b = lam
                     (
@@ -910,7 +909,6 @@ class VirtualSites(StageBase):
                     error = two_site_fit.fun
                     q, lam_a, lam_b = two_site_fit.x
                     q_a = q_b = q
-                    print(f'2 VS: lama lamb q_a q_b error: {lam_a} {lam_b} {q_a} {q_b} {error}')
                     # lam_a = lam_b = lam
                     (
                         site_a_coords,

--- a/qubekit/tests/non_bonded/virtual_sites_test.py
+++ b/qubekit/tests/non_bonded/virtual_sites_test.py
@@ -291,7 +291,7 @@ def test_vsite_opt_angles(methanol, vs, tmpdir):
         # work out the angle
         b1, b2 = sites[0] - center_atom, sites[1] - center_atom
         cosine_angle = np.dot(b1, b2) / (np.linalg.norm(b1) * np.linalg.norm(b2))
-        assert pytest.approx(110.6, abs=0.1) == np.degrees(np.arccos(cosine_angle))
+        assert pytest.approx(110.6, abs=1) == np.degrees(np.arccos(cosine_angle))
 
 
 def test_vsite_reg(methanol, vs, tmpdir):

--- a/qubekit/tests/non_bonded/virtual_sites_test.py
+++ b/qubekit/tests/non_bonded/virtual_sites_test.py
@@ -264,6 +264,10 @@ def test_vsite_frozen_angles(methanol, vs, tmpdir):
         cosine_angle = np.dot(b1, b2) / (np.linalg.norm(b1) * np.linalg.norm(b2))
         assert pytest.approx(90) == np.degrees(np.arccos(cosine_angle))
 
+        # work out the distance this should be around 1
+        for site in sites:
+            assert np.linalg.norm(center_atom - site) == pytest.approx(0.95, abs=0.01)
+
 
 def test_vsite_opt_angles(methanol, vs, tmpdir):
     """
@@ -287,4 +291,28 @@ def test_vsite_opt_angles(methanol, vs, tmpdir):
         # work out the angle
         b1, b2 = sites[0] - center_atom, sites[1] - center_atom
         cosine_angle = np.dot(b1, b2) / (np.linalg.norm(b1) * np.linalg.norm(b2))
-        assert pytest.approx(110.1, abs=0.1) == np.degrees(np.arccos(cosine_angle))
+        assert pytest.approx(110.6, abs=0.1) == np.degrees(np.arccos(cosine_angle))
+
+
+def test_vsite_reg(methanol, vs, tmpdir):
+    """
+    Make the regularisation is correctly turned on when requested.
+    """
+    with tmpdir.as_cwd():
+        vs.freeze_site_angles = True
+        vs.regularisation_epsilon = 0.1
+        vs.run(molecule=methanol)
+        assert methanol.extra_sites.n_sites == 2
+
+        # check the total distance the site is from the parent
+        sites = []
+        center_atom = None
+        with open("xyz_with_extra_point_charges.xyz") as xyz:
+            for line in xyz.readlines():
+                if line.startswith("X"):
+                    sites.append(np.array([float(x) for x in line.split()[1:4]]))
+                elif line.startswith("O"):
+                    center_atom = np.array([float(x) for x in line.split()[1:4]])
+        # work out the distance
+        for site in sites:
+            assert np.linalg.norm(center_atom - site) == pytest.approx(0.29, abs=0.01)


### PR DESCRIPTION
## Description
This PR adds vsite-parent distance regularisation to the objective function using L1 regularisation.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] add tests

## Questions
- [x] The performance of the vsite fits will be slightly different as the mean absolute error is now compared in the objective function rather than the sum of the absolute error and so very slightly different positions and charges will be selected. Do we need to benchmark this change in the default performance?

## Status
- [x] Ready to go