### PR TITLE
Offxml plugin

### DIFF
--- a/qubekit/cli/combine.py
+++ b/qubekit/cli/combine.py
@@ -96,12 +96,12 @@ def _get_eval_string_offxml(
     """
 
     if a_and_b:
-        alpha = "PARM['/vdW/alpha']"
-        beta = "PARM['/vdW/beta']"
+        alpha = "PARM['/QUBEKitvdW/alpha']"
+        beta = "PARM['/QUBEKitvdW/beta']"
     else:
         alpha, beta = alpha_ref, beta_ref
     if rfree_code is not None:
-        rfree = f"PARM['/vdW/{rfree_code.lower()}free']"
+        rfree = f"PARM['/QUBEKitvdW/{rfree_code.lower()}free']"
     else:
         rfree = f"{rfree_data['r_free']}"
 

--- a/qubekit/cli/utils.py
+++ b/qubekit/cli/utils.py
@@ -121,7 +121,7 @@ class QUBEKitHandler(vdWHandler):
             if ref_mol == water:
                 continue
 
-            # if the molecule is water skip it
+            # if the molecule has no conformer generate one
             if ref_mol.n_conformers == 0:
                 ref_mol.generate_conformers(n_conformers=1)
 

--- a/qubekit/cli/utils.py
+++ b/qubekit/cli/utils.py
@@ -1,0 +1,26 @@
+from openff.toolkit.typing.engines.smirnoff.parameters import (
+    ParameterAttribute,
+    vdWHandler,
+)
+from openmm import unit
+
+
+class QUBEKitHandler(vdWHandler):
+    """A plugin handler to enable the fitting of Rfree parameters using evaluator"""
+
+    _TAGNAME = "QUBEKitvdW"
+    hfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    xfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    cfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    nfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    ofree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    clfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    sfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    ffree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    brfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    pfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    ifree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    bfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    sifree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    alpha = ParameterAttribute(1, converter=float, unit=unit.angstroms)
+    beta = ParameterAttribute(0, converter=float, unit=unit.angstroms)

--- a/qubekit/cli/utils.py
+++ b/qubekit/cli/utils.py
@@ -1,4 +1,4 @@
-from openff.toolkit.topology import TopologyAtom, TopologyVirtualSite
+from openff.toolkit.topology import Molecule, TopologyAtom, TopologyVirtualSite
 from openff.toolkit.typing.engines.smirnoff.parameters import (
     ParameterAttribute,
     ParameterType,
@@ -27,19 +27,19 @@ from qubekit.nonbonded.protocols import (
 class QUBEKitHandler(vdWHandler):
     """A plugin handler to enable the fitting of Rfree parameters using evaluator"""
 
-    hfree = ParameterAttribute(0, unit=unit.angstroms)
-    xfree = ParameterAttribute(0, unit=unit.angstroms)
-    cfree = ParameterAttribute(0, unit=unit.angstroms)
-    nfree = ParameterAttribute(0, unit=unit.angstroms)
-    ofree = ParameterAttribute(0, unit=unit.angstroms)
-    clfree = ParameterAttribute(0, unit=unit.angstroms)
-    sfree = ParameterAttribute(0, unit=unit.angstroms)
-    ffree = ParameterAttribute(0, unit=unit.angstroms)
-    brfree = ParameterAttribute(0, unit=unit.angstroms)
-    pfree = ParameterAttribute(0, unit=unit.angstroms)
-    ifree = ParameterAttribute(0, unit=unit.angstroms)
-    bfree = ParameterAttribute(0, unit=unit.angstroms)
-    sifree = ParameterAttribute(0, unit=unit.angstroms)
+    hfree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    xfree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    cfree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    nfree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    ofree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    clfree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    sfree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    ffree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    brfree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    pfree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    ifree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    bfree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
+    sifree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
     alpha = ParameterAttribute(1)
     beta = ParameterAttribute(0)
 
@@ -51,13 +51,25 @@ class QUBEKitHandler(vdWHandler):
 
         volume = ParameterAttribute(unit=unit.bohr**3)
 
-    _TAGNAME = "QUBEKitvdW"
+    _TAGNAME = "QUBEKitvdWTS"
     _INFOTYPE = QUBEKitvdWType
-    _DEPENDENCIES = [vdWHandler]
+    _DEPENDENCIES = None  # we might need to depend on vdW if present
 
     def create_force(self, system, topology, **kwargs):
         """over write the force creation to use qubekit"""
-        force = super().create_force(system, topology, **kwargs)
+        # Get the OpenMM Nonbonded force or add if missing
+        existing = [system.getForce(i) for i in range(system.getNumForces())]
+        existing = [f for f in existing if type(f) == self._OPENMMTYPE]
+
+        # if not present make one and add the particles
+        if len(existing) == 0:
+            force = self._OPENMMTYPE()
+            system.addForce(force)
+            # add all atom particles, Vsites are added later
+            for _ in topology.topology_atoms:
+                force.addParticle(0.0, 1.0, 0.0)
+        else:
+            force = existing[0]
 
         # If we're using PME, then the only possible openMM Nonbonded type is LJPME
         if self.method == "PME":
@@ -84,25 +96,31 @@ class QUBEKitHandler(vdWHandler):
 
         lj = LennardJones612(
             free_parameters={
-                "H": h_base(r_free=self.hfree),
-                "C": c_base(r_free=self.cfree),
-                "X": h_base(r_free=self.xfree),
-                "O": o_base(r_free=self.ofree),
-                "N": n_base(r_free=self.nfree),
-                "Cl": cl_base(r_free=self.clfree),
-                "S": s_base(r_free=self.sfree),
-                "F": f_base(r_free=self.ffree),
-                "Br": br_base(r_free=self.brfree),
-                "I": i_base(r_free=self.ifree),
-                "P": p_base(r_free=self.ifree),
-                "B": b_base(r_free=self.bfree),
-                "Si": si_base(r_free=self.sifree),
+                "H": h_base(r_free=self.hfree.value_in_unit(unit.angstroms)),
+                "C": c_base(r_free=self.cfree.value_in_unit(unit.angstroms)),
+                "X": h_base(r_free=self.xfree.value_in_unit(unit.angstroms)),
+                "O": o_base(r_free=self.ofree.value_in_unit(unit.angstroms)),
+                "N": n_base(r_free=self.nfree.value_in_unit(unit.angstroms)),
+                "Cl": cl_base(r_free=self.clfree.value_in_unit(unit.angstroms)),
+                "S": s_base(r_free=self.sfree.value_in_unit(unit.angstroms)),
+                "F": f_base(r_free=self.ffree.value_in_unit(unit.angstroms)),
+                "Br": br_base(r_free=self.brfree.value_in_unit(unit.angstroms)),
+                "I": i_base(r_free=self.ifree.value_in_unit(unit.angstroms)),
+                "P": p_base(r_free=self.ifree.value_in_unit(unit.angstroms)),
+                "B": b_base(r_free=self.bfree.value_in_unit(unit.angstroms)),
+                "Si": si_base(r_free=self.sifree.value_in_unit(unit.angstroms)),
             },
             alpha=self.alpha,
             beta=self.beta,
         )
 
+        water = Molecule.from_smiles("O")
+
         for ref_mol in topology.reference_molecules:
+            # skip any waters
+            if ref_mol == water:
+                continue
+
             # if the molecule is water skip it
             if ref_mol.n_conformers == 0:
                 ref_mol.generate_conformers(n_conformers=1)
@@ -113,7 +131,9 @@ class QUBEKitHandler(vdWHandler):
                     parameter.smirks, unique=False
                 )
                 for match in matches:
-                    qb_mol.atoms[match[0]].aim.volume = parameter.volume
+                    qb_mol.atoms[match[0]].aim.volume = parameter.volume.value_in_unit(
+                        unit.angstroms**3
+                    )
             # make sure all atoms in the molecule have volumes, assign dummy values
             for i in range(qb_mol.n_atoms):
                 atom = qb_mol.atoms[i]
@@ -154,3 +174,62 @@ class QUBEKitHandler(vdWHandler):
                         particle_parameters.sigma,
                         particle_parameters.epsilon,
                     )
+
+
+class QUBEKitvdWHandler(vdWHandler):
+    """
+    A subclass of the normal vdWhandler to use for qubekit optimisations so we can mix water models with our custom handler
+    """
+
+    _TAGNAME = "QUBEKitvdW"
+
+    def create_force(self, system, topology, **kwargs):
+        # Get the OpenMM Nonbonded force or add if missing
+        existing = [system.getForce(i) for i in range(system.getNumForces())]
+        existing = [f for f in existing if type(f) == self._OPENMMTYPE]
+
+        # if not present make one and add the particles
+        if len(existing) == 0:
+            force = self._OPENMMTYPE()
+            system.addForce(force)
+            # add all atom particles, Vsites are added later
+            for _ in topology.topology_atoms:
+                force.addParticle(0.0, 1.0, 0.0)
+        else:
+            force = existing[0]
+
+        # If we're using PME, then the only possible openMM Nonbonded type is LJPME
+        if self.method == "PME":
+            # If we're given a nonperiodic box, we always set NoCutoff. Later we'll add support for CutoffNonPeriodic
+            if topology.box_vectors is None:
+                force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+                # if (topology.box_vectors is None):
+                #     raise SMIRNOFFSpecError("If vdW method is  PME, a periodic Topology "
+                #                             "must be provided")
+            else:
+                force.setNonbondedMethod(openmm.NonbondedForce.LJPME)
+                force.setCutoffDistance(self.cutoff)
+                force.setEwaldErrorTolerance(1.0e-4)
+
+        # If method is cutoff, then we currently support openMM's PME for periodic system and NoCutoff for nonperiodic
+        elif self.method == "cutoff":
+            # If we're given a nonperiodic box, we always set NoCutoff. Later we'll add support for CutoffNonPeriodic
+            if topology.box_vectors is None:
+                force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+            else:
+                force.setNonbondedMethod(openmm.NonbondedForce.PME)
+                force.setUseDispersionCorrection(True)
+                force.setCutoffDistance(self.cutoff)
+
+        # Iterate over all defined Lennard-Jones types, allowing later matches to override earlier ones.
+        atom_matches = self.find_matches(topology)
+
+        # Set the particle Lennard-Jones terms.
+        for atom_key, atom_match in atom_matches.items():
+            atom_idx = atom_key[0]
+            ljtype = atom_match.parameter_type
+            if ljtype.sigma is None:
+                sigma = 2.0 * ljtype.rmin_half / (2.0 ** (1.0 / 6.0))
+            else:
+                sigma = ljtype.sigma
+            force.setParticleParameters(atom_idx, 0.0, sigma, ljtype.epsilon)

--- a/qubekit/cli/utils.py
+++ b/qubekit/cli/utils.py
@@ -1,26 +1,156 @@
+from openff.toolkit.topology import TopologyAtom, TopologyVirtualSite
 from openff.toolkit.typing.engines.smirnoff.parameters import (
     ParameterAttribute,
+    ParameterType,
     vdWHandler,
 )
-from openmm import unit
+from openmm import openmm, unit
+
+from qubekit.molecules import Ligand
+from qubekit.nonbonded import LennardJones612
+from qubekit.nonbonded.protocols import (
+    b_base,
+    br_base,
+    c_base,
+    cl_base,
+    f_base,
+    h_base,
+    i_base,
+    n_base,
+    o_base,
+    p_base,
+    s_base,
+    si_base,
+)
 
 
 class QUBEKitHandler(vdWHandler):
     """A plugin handler to enable the fitting of Rfree parameters using evaluator"""
 
+    hfree = ParameterAttribute(0, unit=unit.angstroms)
+    xfree = ParameterAttribute(0, unit=unit.angstroms)
+    cfree = ParameterAttribute(0, unit=unit.angstroms)
+    nfree = ParameterAttribute(0, unit=unit.angstroms)
+    ofree = ParameterAttribute(0, unit=unit.angstroms)
+    clfree = ParameterAttribute(0, unit=unit.angstroms)
+    sfree = ParameterAttribute(0, unit=unit.angstroms)
+    ffree = ParameterAttribute(0, unit=unit.angstroms)
+    brfree = ParameterAttribute(0, unit=unit.angstroms)
+    pfree = ParameterAttribute(0, unit=unit.angstroms)
+    ifree = ParameterAttribute(0, unit=unit.angstroms)
+    bfree = ParameterAttribute(0, unit=unit.angstroms)
+    sifree = ParameterAttribute(0, unit=unit.angstroms)
+    alpha = ParameterAttribute(1)
+    beta = ParameterAttribute(0)
+
+    class QUBEKitvdWType(ParameterType):
+        """A dummy vdw type which just stores the volume and so we can build the system correctly"""
+
+        _VALENCE_TYPE = "Atom"  # ChemicalEnvironment valence type expected for SMARTS
+        _ELEMENT_NAME = "Atom"
+
+        volume = ParameterAttribute(unit=unit.bohr**3)
+
     _TAGNAME = "QUBEKitvdW"
-    hfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    xfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    cfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    nfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    ofree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    clfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    sfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    ffree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    brfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    pfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    ifree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    bfree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    sifree = ParameterAttribute(0, converter=float, unit=unit.angstroms)
-    alpha = ParameterAttribute(1, converter=float, unit=unit.angstroms)
-    beta = ParameterAttribute(0, converter=float, unit=unit.angstroms)
+    _INFOTYPE = QUBEKitvdWType
+    _DEPENDENCIES = [vdWHandler]
+
+    def create_force(self, system, topology, **kwargs):
+        """over write the force creation to use qubekit"""
+        force = super().create_force(system, topology, **kwargs)
+
+        # If we're using PME, then the only possible openMM Nonbonded type is LJPME
+        if self.method == "PME":
+            # If we're given a nonperiodic box, we always set NoCutoff. Later we'll add support for CutoffNonPeriodic
+            if topology.box_vectors is None:
+                force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+                # if (topology.box_vectors is None):
+                #     raise SMIRNOFFSpecError("If vdW method is  PME, a periodic Topology "
+                #                             "must be provided")
+            else:
+                force.setNonbondedMethod(openmm.NonbondedForce.LJPME)
+                force.setCutoffDistance(self.cutoff)
+                force.setEwaldErrorTolerance(1.0e-4)
+
+        # If method is cutoff, then we currently support openMM's PME for periodic system and NoCutoff for nonperiodic
+        elif self.method == "cutoff":
+            # If we're given a nonperiodic box, we always set NoCutoff. Later we'll add support for CutoffNonPeriodic
+            if topology.box_vectors is None:
+                force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+            else:
+                force.setNonbondedMethod(openmm.NonbondedForce.PME)
+                force.setUseDispersionCorrection(True)
+                force.setCutoffDistance(self.cutoff)
+
+        lj = LennardJones612(
+            free_parameters={
+                "H": h_base(r_free=self.hfree),
+                "C": c_base(r_free=self.cfree),
+                "X": h_base(r_free=self.xfree),
+                "O": o_base(r_free=self.ofree),
+                "N": n_base(r_free=self.nfree),
+                "Cl": cl_base(r_free=self.clfree),
+                "S": s_base(r_free=self.sfree),
+                "F": f_base(r_free=self.ffree),
+                "Br": br_base(r_free=self.brfree),
+                "I": i_base(r_free=self.ifree),
+                "P": p_base(r_free=self.ifree),
+                "B": b_base(r_free=self.bfree),
+                "Si": si_base(r_free=self.sifree),
+            },
+            alpha=self.alpha,
+            beta=self.beta,
+        )
+
+        for ref_mol in topology.reference_molecules:
+            # if the molecule is water skip it
+            if ref_mol.n_conformers == 0:
+                ref_mol.generate_conformers(n_conformers=1)
+
+            qb_mol = Ligand.from_rdkit(ref_mol.to_rdkit())
+            for parameter in self.parameters:
+                matches = ref_mol.chemical_environment_matches(
+                    parameter.smirks, unique=False
+                )
+                for match in matches:
+                    qb_mol.atoms[match[0]].aim.volume = parameter.volume
+            # make sure all atoms in the molecule have volumes, assign dummy values
+            for i in range(qb_mol.n_atoms):
+                atom = qb_mol.atoms[i]
+                assert atom.aim.volume is not None
+                qb_mol.NonbondedForce.create_parameter(
+                    atoms=(i,), charge=0, sigma=0, epsilon=0
+                )
+
+            # calculate the nonbonded terms
+            lj.run(qb_mol)
+
+            # assign to all copies in the system
+            for topology_molecule in topology._reference_molecule_to_topology_molecules[
+                ref_mol
+            ]:
+                for topology_particle in topology_molecule.atoms:
+                    if type(topology_particle) is TopologyAtom:
+                        ref_mol_particle_index = (
+                            topology_particle.atom.molecule_particle_index
+                        )
+                    elif type(topology_particle) is TopologyVirtualSite:
+                        ref_mol_particle_index = (
+                            topology_particle.virtual_site.molecule_particle_index
+                        )
+                    else:
+                        raise ValueError(
+                            f"Particles of type {type(topology_particle)} are not supported"
+                        )
+
+                    topology_particle_index = topology_particle.topology_particle_index
+                    particle_parameters = qb_mol.NonbondedForce[
+                        (ref_mol_particle_index,)
+                    ]
+                    # Set the nonbonded force parameters
+                    force.setParticleParameters(
+                        topology_particle_index,
+                        particle_parameters.charge,  # this is a dummy charge which needs to be corrected
+                        particle_parameters.sigma,
+                        particle_parameters.epsilon,
+                    )

--- a/qubekit/tests/cli/test_combine.py
+++ b/qubekit/tests/cli/test_combine.py
@@ -5,24 +5,24 @@ from xml.dom.minidom import parseString
 import pytest
 import xmltodict
 from deepdiff import DeepDiff
-from openff.toolkit.topology import Molecule
+from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.typing.engines.smirnoff import ForceField
-from openmm import XmlSerializer, app
+from openmm import XmlSerializer, app, openmm, unit
 
 import qubekit
+from qubekit.charges import MBISCharges
 from qubekit.cli.combine import (
     _combine_molecules,
     _combine_molecules_offxml,
     _find_molecules_and_rfrees,
     _get_eval_string,
-    _get_eval_string_offxml,
     _get_parameter_code,
     _update_increment,
     combine,
     elements,
 )
 from qubekit.molecules import Ligand
-from qubekit.nonbonded import get_protocol
+from qubekit.nonbonded import LennardJones612, get_protocol
 from qubekit.utils import constants
 from qubekit.utils.file_handling import get_data
 
@@ -131,54 +131,54 @@ def test_get_eval_string(atom, a_and_b, rfree_code, expected, coumarin):
     assert eval_string == expected, print(eval_string)
 
 
-@pytest.mark.parametrize(
-    "atom, a_and_b, rfree_code, expected",
-    [
-        pytest.param(
-            1,
-            True,
-            "C",
-            f"epsilon=(PARM['/vdW/alpha']*46.6*(21.129491/34.4)**PARM['/vdW/beta'])/(128*PARM['/vdW/cfree']**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*PARM['/vdW/cfree']*{constants.SIGMA_CONVERSION}",
-            id="AB Rfree",
-        ),
-        pytest.param(
-            1,
-            False,
-            "C",
-            f"epsilon=(1.32*46.6*(21.129491/34.4)**0.469)/(128*PARM['/vdW/cfree']**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*PARM['/vdW/cfree']*{constants.SIGMA_CONVERSION}",
-            id="No AB Rfree",
-        ),
-        pytest.param(
-            1,
-            True,
-            None,
-            f"epsilon=(PARM['/vdW/alpha']*46.6*(21.129491/34.4)**PARM['/vdW/beta'])/(128*2**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*2*{constants.SIGMA_CONVERSION}",
-            id="AB No Rfree",
-        ),
-        pytest.param(
-            1,
-            False,
-            None,
-            f"epsilon=(1.32*46.6*(21.129491/34.4)**0.469)/(128*2**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*2*{constants.SIGMA_CONVERSION}",
-            id="No AB No Rfree",
-        ),
-    ],
-)
-def test_get_eval_string_offxml(atom, a_and_b, rfree_code, expected, coumarin):
-    """
-    Test generating the eval string for an offxml with different settings.
-    """
-    rfree_data = {"v_free": 34.4, "b_free": 46.6, "r_free": 2}  # carbon
-
-    eval_string = _get_eval_string_offxml(
-        atom=coumarin.atoms[atom],
-        rfree_data=rfree_data,
-        a_and_b=a_and_b,
-        rfree_code=rfree_code,
-        alpha_ref="1.32",
-        beta_ref="0.469",
-    )
-    assert eval_string == expected, print(eval_string)
+# @pytest.mark.parametrize(
+#     "atom, a_and_b, rfree_code, expected",
+#     [
+#         pytest.param(
+#             1,
+#             True,
+#             "C",
+#             f"epsilon=(PARM['/vdW/alpha']*46.6*(21.129491/34.4)**PARM['/vdW/beta'])/(128*PARM['/vdW/cfree']**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*PARM['/vdW/cfree']*{constants.SIGMA_CONVERSION}",
+#             id="AB Rfree",
+#         ),
+#         pytest.param(
+#             1,
+#             False,
+#             "C",
+#             f"epsilon=(1.32*46.6*(21.129491/34.4)**0.469)/(128*PARM['/vdW/cfree']**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*PARM['/vdW/cfree']*{constants.SIGMA_CONVERSION}",
+#             id="No AB Rfree",
+#         ),
+#         pytest.param(
+#             1,
+#             True,
+#             None,
+#             f"epsilon=(PARM['/vdW/alpha']*46.6*(21.129491/34.4)**PARM['/vdW/beta'])/(128*2**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*2*{constants.SIGMA_CONVERSION}",
+#             id="AB No Rfree",
+#         ),
+#         pytest.param(
+#             1,
+#             False,
+#             None,
+#             f"epsilon=(1.32*46.6*(21.129491/34.4)**0.469)/(128*2**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*2*{constants.SIGMA_CONVERSION}",
+#             id="No AB No Rfree",
+#         ),
+#     ],
+# )
+# def test_get_eval_string_offxml(atom, a_and_b, rfree_code, expected, coumarin):
+#     """
+#     Test generating the eval string for an offxml with different settings.
+#     """
+#     rfree_data = {"v_free": 34.4, "b_free": 46.6, "r_free": 2}  # carbon
+#
+#     eval_string = _get_eval_string_offxml(
+#         atom=coumarin.atoms[atom],
+#         rfree_data=rfree_data,
+#         a_and_b=a_and_b,
+#         rfree_code=rfree_code,
+#         alpha_ref="1.32",
+#         beta_ref="0.469",
+#     )
+#     assert eval_string == expected, print(eval_string)
 
 
 def test_combine_molecules_deepdiff(acetone, openff, coumarin, tmpdir, rfree_data):
@@ -347,11 +347,11 @@ def test_combine_cli_all(
 @pytest.mark.parametrize(
     "parameters, expected",
     [
-        pytest.param(["-p", "C"], 2, id="Only C"),
+        pytest.param(["-p", "C"], 1, id="Only C"),
         pytest.param(
-            ["-p", "C", "-p", "AB", "-p", "N", "-p", "O"], 6, id="CNO alpha beta"
+            ["-p", "C", "-p", "AB", "-p", "N", "-p", "O"], 5, id="CNO alpha beta"
         ),
-        pytest.param([], 8, id="All present"),
+        pytest.param([], 7, id="All present"),
         pytest.param(["--no-targets"], 0, id="No targets"),
     ],
 )
@@ -379,9 +379,20 @@ def test_combine_cli_all_offxml(
         assert output.exit_code == 0
         assert "2 molecules found, combining..." in output.output
 
-        ff = ForceField("combined.offxml", allow_cosmetic_attributes=True)
-        vdw_handler = ff.get_parameter_handler("vdW")
-        assert len(vdw_handler._cosmetic_attribs) == expected
+        if expected != 0:
+            ff = ForceField(
+                "combined.offxml", allow_cosmetic_attributes=True, load_plugins=True
+            )
+            # make sure we have used the plugin method
+            vdw_handler = ff.get_parameter_handler("QUBEKitvdWTS")
+            assert len(vdw_handler.parameters) == 32
+            assert "parameterize" in vdw_handler._cosmetic_attribs
+            assert len(getattr(vdw_handler, "_parameterize").split(",")) == expected
+        else:
+            # we are using the normal format so make sure it complies
+            ff = ForceField("combined.offxml")
+            vdw_handler = ff.get_parameter_handler("vdW")
+            assert len(vdw_handler.parameters) == 34
 
 
 def test_combine_sites_offxml(xml, tmpdir, rfree_data):
@@ -424,6 +435,7 @@ def test_combine_rb_offxml(tmpdir, xml, rfree_data):
 def test_combine_molecules_deepdiff_offxml(
     acetone, openff, coumarin, tmpdir, rfree_data
 ):
+    """When not optimising anything make sure we can round trip openff parameters"""
 
     with tmpdir.as_cwd():
         openff.run(acetone)
@@ -433,13 +445,13 @@ def test_combine_molecules_deepdiff_offxml(
 
         _combine_molecules_offxml(
             molecules=[acetone, coumarin],
-            parameters=elements,
+            parameters=[],
             rfree_data=rfree_data,
             filename="combined.offxml",
         )
 
         # load up new systems and compare
-        combinded_ff = ForceField("combined.offxml", allow_cosmetic_attributes=True)
+        combinded_ff = ForceField("combined.offxml")
         assert combinded_ff.author == f"QUBEKit_version_{qubekit.__version__}"
 
         acetone_combine_system = xmltodict.parse(
@@ -472,6 +484,144 @@ def test_combine_molecules_deepdiff_offxml(
             coumarin_combine_system,
             ignore_order=True,
             significant_digits=6,
+        )
+        assert len(coumarin_diff) == 1
+        for item in coumarin_diff["iterable_item_added"].values():
+            assert item["@k"] == "0"
+
+
+def test_molecule_and_water_offxml(coumarin, water, tmpdir, rfree_data):
+    """Test that an offxml can parameterize a molecule and water mixture."""
+
+    with tmpdir.as_cwd():
+
+        _combine_molecules_offxml(
+            molecules=[coumarin],
+            parameters=[],
+            rfree_data=rfree_data,
+            filename="combined.offxml",
+            water_model="tip3p",
+        )
+
+        combinded_ff = ForceField(
+            "combined.offxml", load_plugins=True, allow_cosmetic_attributes=True
+        )
+        mixed_top = Topology.from_molecules(
+            molecules=[
+                Molecule.from_rdkit(water.to_rdkit()),
+                Molecule.from_rdkit(coumarin.to_rdkit()),
+            ]
+        )
+        system = combinded_ff.create_openmm_system(topology=mixed_top)
+        # make sure we have 3 constraints
+        assert system.getNumConstraints() == 3
+        # check each constraint
+        reference_constraints = [
+            [0, 1, unit.Quantity(0.9572, unit=unit.angstroms)],
+            [0, 2, unit.Quantity(0.9572, unit=unit.angstroms)],
+            [1, 2, unit.Quantity(1.5139006545247014, unit=unit.angstroms)],
+        ]
+        for i in range(3):
+            a, b, constraint = system.getConstraintParameters(i)
+            assert a == reference_constraints[i][0]
+            assert b == reference_constraints[i][1]
+            assert constraint == reference_constraints[i][2].in_units_of(
+                unit.nanometers
+            )
+        # now loop over the forces and make sure water was correctly parameterised
+        forces = dict((force.__class__.__name__, force) for force in system.getForces())
+        nonbonded_force: openmm.NonbondedForce = forces["NonbondedForce"]
+        # first check water has the correct parameters
+        water_reference = [
+            [
+                unit.Quantity(-0.834, unit.elementary_charge),
+                unit.Quantity(3.1507, unit=unit.angstroms),
+                unit.Quantity(0.1521, unit=unit.kilocalorie_per_mole),
+            ],
+            [
+                unit.Quantity(0.417, unit.elementary_charge),
+                unit.Quantity(1, unit=unit.angstroms),
+                unit.Quantity(0, unit=unit.kilocalorie_per_mole),
+            ],
+            [
+                unit.Quantity(0.417, unit.elementary_charge),
+                unit.Quantity(1, unit=unit.angstroms),
+                unit.Quantity(0, unit=unit.kilocalorie_per_mole),
+            ],
+        ]
+        for i in range(3):
+            charge, sigma, epsilon = nonbonded_force.getParticleParameters(i)
+            assert charge == water_reference[i][0]
+            assert sigma.in_units_of(unit.angstroms) == water_reference[i][1]
+            assert (
+                epsilon.in_units_of(unit.kilocalorie_per_mole) == water_reference[i][2]
+            )
+
+        # now check coumarin
+        for i in range(coumarin.n_atoms):
+            ref_params = coumarin.NonbondedForce[(i,)]
+            charge, sigma, epsilon = nonbonded_force.getParticleParameters(i + 3)
+            assert charge.value_in_unit(unit.elementary_charge) == float(
+                ref_params.charge
+            )
+            assert sigma.value_in_unit(unit.nanometers) == ref_params.sigma
+            assert epsilon.value_in_unit(unit.kilojoule_per_mole) == ref_params.epsilon
+
+
+def test_combine_molecules_offxml_plugin_deepdiff(tmpdir, coumarin, rfree_data):
+    """Make sure that systems made from molecules using the xml method match offxmls with plugins"""
+
+    # we need to recalculate the Nonbonded terms using the fake Rfree
+    coumarin_copy = coumarin.copy(deep=True)
+    # apply symmetry to make sure systems match
+    MBISCharges.apply_symmetrisation(coumarin_copy)
+    with tmpdir.as_cwd():
+        # make the offxml using the plugin interface
+        _combine_molecules_offxml(
+            molecules=[coumarin_copy],
+            parameters=elements,
+            rfree_data=rfree_data,
+            filename="openff.offxml",
+            water_model="tip3p",
+        )
+        offxml = ForceField(
+            "openff.offxml", load_plugins=True, allow_cosmetic_attributes=True
+        )
+        # check the plugin is being used
+        vdw = offxml.get_parameter_handler("QUBEKitvdWTS")
+        # make sure we have the parameterize tags
+        assert len(vdw._cosmetic_attribs) == 1
+        assert len(vdw.parameters) == 28
+
+        alpha = rfree_data.pop("alpha")
+        beta = rfree_data.pop("beta")
+        lj = LennardJones612(free_parameters=rfree_data, alpha=alpha, beta=beta)
+        # get new Rfree data
+        lj.run(coumarin_copy)
+        coumarin_copy.write_parameters("coumarin.xml")
+        coumarin_ref_system = xmltodict.parse(
+            XmlSerializer.serialize(
+                app.ForceField("coumarin.xml").createSystem(
+                    topology=coumarin_copy.to_openmm_topology(),
+                    nonbondedCutoff=9 * unit.angstroms,
+                    removeCMMotion=False,
+                )
+            )
+        )
+        coumarin_off_system = xmltodict.parse(
+            XmlSerializer.serialize(
+                offxml.create_openmm_system(
+                    Molecule.from_rdkit(coumarin_copy.to_rdkit()).to_topology()
+                )
+            )
+        )
+
+        coumarin_diff = DeepDiff(
+            coumarin_ref_system,
+            coumarin_off_system,
+            ignore_order=True,
+            significant_digits=6,
+            exclude_regex_paths="mass",
         )
         assert len(coumarin_diff) == 1
         for item in coumarin_diff["iterable_item_added"].values():

--- a/qubekit/tests/cli/test_combine.py
+++ b/qubekit/tests/cli/test_combine.py
@@ -131,56 +131,6 @@ def test_get_eval_string(atom, a_and_b, rfree_code, expected, coumarin):
     assert eval_string == expected, print(eval_string)
 
 
-# @pytest.mark.parametrize(
-#     "atom, a_and_b, rfree_code, expected",
-#     [
-#         pytest.param(
-#             1,
-#             True,
-#             "C",
-#             f"epsilon=(PARM['/vdW/alpha']*46.6*(21.129491/34.4)**PARM['/vdW/beta'])/(128*PARM['/vdW/cfree']**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*PARM['/vdW/cfree']*{constants.SIGMA_CONVERSION}",
-#             id="AB Rfree",
-#         ),
-#         pytest.param(
-#             1,
-#             False,
-#             "C",
-#             f"epsilon=(1.32*46.6*(21.129491/34.4)**0.469)/(128*PARM['/vdW/cfree']**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*PARM['/vdW/cfree']*{constants.SIGMA_CONVERSION}",
-#             id="No AB Rfree",
-#         ),
-#         pytest.param(
-#             1,
-#             True,
-#             None,
-#             f"epsilon=(PARM['/vdW/alpha']*46.6*(21.129491/34.4)**PARM['/vdW/beta'])/(128*2**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*2*{constants.SIGMA_CONVERSION}",
-#             id="AB No Rfree",
-#         ),
-#         pytest.param(
-#             1,
-#             False,
-#             None,
-#             f"epsilon=(1.32*46.6*(21.129491/34.4)**0.469)/(128*2**6)*{constants.EPSILON_CONVERSION}, sigma=2**(5/6)*(21.129491/34.4)**(1/3)*2*{constants.SIGMA_CONVERSION}",
-#             id="No AB No Rfree",
-#         ),
-#     ],
-# )
-# def test_get_eval_string_offxml(atom, a_and_b, rfree_code, expected, coumarin):
-#     """
-#     Test generating the eval string for an offxml with different settings.
-#     """
-#     rfree_data = {"v_free": 34.4, "b_free": 46.6, "r_free": 2}  # carbon
-#
-#     eval_string = _get_eval_string_offxml(
-#         atom=coumarin.atoms[atom],
-#         rfree_data=rfree_data,
-#         a_and_b=a_and_b,
-#         rfree_code=rfree_code,
-#         alpha_ref="1.32",
-#         beta_ref="0.469",
-#     )
-#     assert eval_string == expected, print(eval_string)
-
-
 def test_combine_molecules_deepdiff(acetone, openff, coumarin, tmpdir, rfree_data):
 
     with tmpdir.as_cwd():

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ setup(
             "QUBEKit = qubekit.cli.cli:cli",
             "qubekit = qubekit.cli.cli:cli",
             "QUBEKit-pro = qubekit.proteins.protein_run:main",
+        ],
+        "openff.toolkit.plugins.handlers": [
+            "QUBEKitvdW = qubekit.cli.utils:QUBEKitHandler"
         ]
     },
     version=versioneer.get_version(),

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
             "QUBEKit-pro = qubekit.proteins.protein_run:main",
         ],
         "openff.toolkit.plugins.handlers": [
-            "QUBEKitvdW = qubekit.cli.utils:QUBEKitHandler"
+            "QUBEKitvdWTS = qubekit.cli.utils:QUBEKitHandler",
+            "QUBEKitvdW = qubekit.cli.utils:QUBEKitvdWHandler"
         ]
     },
     version=versioneer.get_version(),


### PR DESCRIPTION
## Description
This PR updates the offxml combine method to use a plugin which avoids the use of parameter eval statements. Here we assign each atom a volume via smirks and use a custom vdW handler with Rfree, alpha and beta global attributes which can be optimised with Forcebalance. We also add support for TIP3P water in the offxml. If parameters are not to be optimised a standard offxml is made using the default vdW handler.


## Status
- [ ] Ready to go