### PR TITLE
Allow ANI to be used to calculate the hessian

### DIFF
--- a/qubekit/cli/combine.py
+++ b/qubekit/cli/combine.py
@@ -140,7 +140,7 @@ def _add_water_model(
             }
         )
         if using_plugin:
-            # if we are using the pluing to optimise the molecule we need a secial vdw handler
+            # if we are using the plugin to optimise the molecule we need a special vdw handler
             vdw_handler = force_field.get_parameter_handler("QUBEKitvdW")
         else:
             vdw_handler = force_field.get_parameter_handler("vdW")

--- a/qubekit/tests/workflow/test_helper_stages.py
+++ b/qubekit/tests/workflow/test_helper_stages.py
@@ -1,0 +1,18 @@
+from qubekit.utils.datastructures import LocalResource, QCOptions
+from qubekit.workflow.helper_stages import Hessian
+
+
+def test_ani_hessian(acetone, tmpdir):
+    """
+    Test computing the hessian using ml, note this will not provide the wbo matrix
+    """
+    with tmpdir.as_cwd():
+        # make sure the hessian has not already been assigned by mistake
+        assert acetone.hessian is None
+        spec = QCOptions(program="torchani", basis=None, method="ani2x")
+        options = LocalResource(cores=1, memory=1)
+        hes_stage = Hessian()
+        hes_stage.run(molecule=acetone, qc_spec=spec, local_options=options)
+        assert acetone.wbo is None
+        assert acetone.hessian is not None
+        assert acetone.hessian.shape == (30, 30)

--- a/qubekit/workflow/helper_stages.py
+++ b/qubekit/workflow/helper_stages.py
@@ -69,7 +69,8 @@ class Hessian(StageBase):
 
         np.savetxt("hessian.txt", result.return_result)
         molecule.hessian = result.return_result
-        molecule.wbo = result.extras["qcvars"]["WIBERG_LOWDIN_INDICES"]
+        if "qcvars" in result.extras:
+            molecule.wbo = result.extras["qcvars"]["WIBERG_LOWDIN_INDICES"]
         check_symmetry(molecule.hessian)
         return molecule
 


### PR DESCRIPTION
## Description
This PR fixes a bug where we assumed the wbo matrix was also calculated with the hessian. This means the wbo matrix will be missing later which will cause issues when using hessian fitting with QForce. 


## Status
- [ ] Ready to go