### PR TITLE
Fix checkpointing the torsiondrive state file

### DIFF
--- a/qubekit/engines/qcengine.py
+++ b/qubekit/engines/qcengine.py
@@ -46,7 +46,7 @@ def call_qcengine(
     )
 
     result = qcng.compute(
-        task, qc_spec.program, local_options=local_options.local_options
+        task, qc_spec.program, task_config=local_options.local_options
     )
     with open("qcengine_result.json", "w") as output:
         output.write(result.json())

--- a/qubekit/tests/engines/gaussian_harness_test.py
+++ b/qubekit/tests/engines/gaussian_harness_test.py
@@ -119,7 +119,7 @@ def test_gaussian_td_settings(tmpdir, water, use_tda, theory):
             keywords={"tdscf_states": 10, "tdscf_tda": use_tda},
         )
         gaussian_harness = GaussianHarness()
-        config = qcng.config.get_config(local_options={"ncores": 1, "memory": 1})
+        config = qcng.config.get_config(task_config={"ncores": 1, "memory": 1})
         job_inputs = gaussian_harness.build_input(task, config)
         job_script = job_inputs["infiles"]["gaussian.com"]
         if use_tda:

--- a/qubekit/tests/engines/gaussian_harness_test.py
+++ b/qubekit/tests/engines/gaussian_harness_test.py
@@ -141,7 +141,7 @@ def test_gaussian_nbo_input_file(tmpdir, water):
         )
         # we need the harness as this will render the template
         gaussian_harness = GaussianHarness()
-        config = qcng.config.get_config(local_options={"ncores": 1, "memory": 1})
+        config = qcng.config.get_config(task_config={"ncores": 1, "memory": 1})
         job_inputs = gaussian_harness.build_input(task, config)
         # make sure the job file matches or expected reference
         with open(get_data("gaussian_nbo_example.com")) as g_out:

--- a/qubekit/tests/non_bonded/test_charges.py
+++ b/qubekit/tests/non_bonded/test_charges.py
@@ -160,7 +160,7 @@ def test_gaussian_no_solvent_template(tmpdir, water):
         )
         # we need the harness as this will render the template
         gaussian_harness = GaussianHarness()
-        config = get_config(local_options={"ncores": 1, "memory": 1})
+        config = get_config(task_config={"ncores": 1, "memory": 1})
         job_inputs = gaussian_harness.build_input(task, config)
         with open(get_data("gaussian_gas_example.com")) as g_out:
             assert g_out.read() == job_inputs["infiles"]["gaussian.com"]

--- a/qubekit/tests/non_bonded/test_charges.py
+++ b/qubekit/tests/non_bonded/test_charges.py
@@ -137,7 +137,7 @@ def test_gaussian_solvent_template(tmpdir, water):
         )
         # we need the harness as this will render the template
         gaussian_harness = GaussianHarness()
-        config = get_config(local_options={"ncores": 1, "memory": 1})
+        config = get_config(task_config={"ncores": 1, "memory": 1})
         job_inputs = gaussian_harness.build_input(task, config)
         # make sure the job file matches or expected reference
         with open(get_data("gaussian_solvent_example.com")) as g_out:


### PR DESCRIPTION
## Description
This PR fixes the way the torsiondrive state file is saved and loaded locally to allow for restarts when the settings match between two runs. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [x] Ready to go