### PR TITLE
Fix WBO qcvars name for gaussian

### DIFF
--- a/qubekit/engines/gaussian_harness.py
+++ b/qubekit/engines/gaussian_harness.py
@@ -293,7 +293,7 @@ class GaussianHarness(ProgramHarness):
 
         # parse scf_properties
         if "scf_properties" in input_model.keywords:
-            qcvars["WIBERG_LOWDIN_INDICES"] = self.parse_wbo(
+            qcvars["WIBERG LOWDIN INDICES"] = self.parse_wbo(
                 logfile=outfiles["gaussian.log"],
                 natoms=len(input_model.molecule.symbols),
             )


### PR DESCRIPTION
## Description
This PR aligns the qcvars name for the WBO matrix from gaussian with psi4, they are now stored under `WIBERG LOWDIN INDICES`

## Status
- [ ] Ready to go