### PR TITLE
Plugin charge fix

### DIFF
--- a/qubekit/cli/utils.py
+++ b/qubekit/cli/utils.py
@@ -194,10 +194,12 @@ class QUBEKitHandler(vdWHandler):
                     particle_parameters = qb_mol.NonbondedForce[
                         (ref_mol_particle_index,)
                     ]
+                    # get the current particle charge as we do not want to change this
+                    charge, _, _ = force.getParticleParameters(topology_particle_index)
                     # Set the nonbonded force parameters
                     force.setParticleParameters(
                         topology_particle_index,
-                        particle_parameters.charge,  # this is a dummy charge which needs to be corrected by a libray charge
+                        charge,  # set with the existing charge do not use the dummy qubekit value!
                         particle_parameters.sigma,
                         particle_parameters.epsilon,
                     )


### PR DESCRIPTION
## Description
This PR fixes a potential issue where the qubekit plugin used for fitting would set charges to dummy values of 0 for everything if the parameter handlers were resolved with library charges before the plugin handler. This change should mean the correct charges are applied regardless of order. 


## Status
- [ ] Ready to go