### PR TITLE
fix plugin sites

### DIFF
--- a/qubekit/cli/utils.py
+++ b/qubekit/cli/utils.py
@@ -342,15 +342,6 @@ class LocalCoordinateVirtualSiteHandler(VirtualSiteHandler):
 
     exclusion_policy = ParameterAttribute(default="parents")
 
-    def check_handler_compatibility(self, other_handler):
-        """
-        This handler is not compatible with the default Vsite handler so make sure an error is raised if they are both found together.
-        """
-        if type(other_handler) == VirtualSiteHandler:
-            raise ValueError(
-                "The LocalCoordinateVirtualSites QUBEKit handler is not compatible with the default v-site handler, please remove it."
-            )
-
     def create_force(self, system: openmm.System, topology: Topology, **kwargs):
 
         # as the normal vsites go first there should be more than topology.n_atoms if we have a 4 site water or more

--- a/qubekit/cli/water_models.py
+++ b/qubekit/cli/water_models.py
@@ -1,6 +1,6 @@
 from openmm import unit
 
-water_models = {
+water_models_local = {
     "tip3p": {
         "Bonds": [
             {
@@ -121,6 +121,131 @@ water_models = {
                 "charge": -1.05174 * unit.elementary_charge,
                 "sigma": 1 * unit.nanometers,
                 "epsilon": 0.0 * unit.kilojoule_per_mole,
+            }
+        ],
+    },
+}
+
+water_models_normal = {
+    "tip3p": {
+        "Bonds": [
+            {
+                "smirks": "[#1:1]-[#8X2H2+0:2]-[#1]",
+                "k": 1087.053566377 * unit.kilocalorie_per_mole / unit.angstroms**2,
+                "length": 0.9572 * unit.angstroms,
+            }
+        ],
+        "Angles": [
+            {
+                "smirks": "[#1:1]-[#8X2H2+0:2]-[#1:3]",
+                "k": 130.181232192 * unit.kilocalorie_per_mole / unit.radian**2,
+                "angle": 110.3538806181 * unit.degree,
+            }
+        ],
+        "Constraints": [
+            {
+                "smirks": "[#1:1]-[#8X2H2+0:2]-[#1]",
+                "id": "c-tip3p-H-O",
+                "distance": 0.9572 * unit.angstroms,
+            },
+            {
+                "smirks": "[#1:1]-[#8X2H2+0]-[#1:2]",
+                "id": "c-tip3p-H-O-H",
+                "distance": 1.5139006545247014 * unit.angstroms,
+            },
+        ],
+        "LibraryCharges": [
+            {
+                "smirks": "[#1]-[#8X2H2+0:1]-[#1]",
+                "charge1": -0.834 * unit.elementary_charge,
+                "id": "q-tip3p-O",
+            },
+            {
+                "smirks": "[#1:1]-[#8X2H2+0]-[#1]",
+                "charge1": 0.417 * unit.elementary_charge,
+                "id": "q-tip3p-H",
+            },
+        ],
+        "Nonbonded": [
+            {
+                "smirks": "[#1]-[#8X2H2+0:1]-[#1]",
+                "epsilon": 0.1521 * unit.kilocalorie_per_mole,
+                "id": "n-tip3p-O",
+                "sigma": 3.1507 * unit.angstroms,
+            },
+            {
+                "smirks": "[#1:1]-[#8X2H2+0]-[#1]",
+                "epsilon": 0 * unit.kilocalorie_per_mole,
+                "id": "n-tip3p-H",
+                "sigma": 1 * unit.angstroms,
+            },
+        ],
+    },
+    "tip4p-fb": {
+        "Bonds": [
+            {
+                "smirks": "[#1:1]-[#8X2H2+0:2]-[#1]",
+                "k": 1087.053566377 * unit.kilocalorie_per_mole / unit.angstroms**2,
+                "length": 0.9572 * unit.angstroms,
+            }
+        ],
+        "Angles": [
+            {
+                "smirks": "[#1:1]-[#8X2H2+0:2]-[#1:3]",
+                "k": 130.181232192 * unit.kilocalorie_per_mole / unit.radian**2,
+                "angle": 110.3538806181 * unit.degree,
+            }
+        ],
+        "Constraints": [
+            {
+                "smirks": "[#1:1]-[#8X2H2+0:2]-[#1]",
+                "id": "c-tip4p-fb-H-O",
+                "distance": 0.9572 * unit.angstroms,
+            },
+            {
+                "smirks": "[#1:1]-[#8X2H2+0]-[#1:2]",
+                "id": "c-tip4p-fb-H-O-H",
+                "distance": 1.5139006545247014 * unit.angstroms,
+            },
+        ],
+        "LibraryCharges": [
+            {
+                "smirks": "[#1]-[#8X2H2+0:1]-[#1]",
+                "charge1": 0 * unit.elementary_charge,
+                "id": "q-tip4p-fb-O",
+            },
+            # charge is set to zero as the v-site will move the charge
+            {
+                "smirks": "[#1:1]-[#8X2H2+0]-[#1]",
+                "charge1": 0 * unit.elementary_charge,
+                "id": "q-tip4p-fb-H",
+            },
+        ],
+        "Nonbonded": [
+            {
+                "smirks": "[#1]-[#8X2H2+0:1]-[#1]",
+                "epsilon": 0.179082 * unit.kilocalorie_per_mole,
+                "id": "n-tip4p-fb-O",
+                "sigma": 3.1655 * unit.angstroms,
+            },
+            {
+                "smirks": "[#1:1]-[#8X2H2+0]-[#1]",
+                "epsilon": 0 * unit.kilocalorie_per_mole,
+                "id": "n-tip4p-fb-H",
+                "sigma": 1 * unit.angstroms,
+            },
+        ],
+        "VirtualSites": [
+            {
+                "smirks": "[#1:2]-[#8X2H2+0:1]-[#1:3]",
+                "type": "DivalentLonePair",
+                "distance": -0.10527 * unit.angstroms,
+                "outOfPlaneAngle": 0.0 * unit.degrees,
+                "match": "once",
+                "charge_increment1": 0.0 * unit.elementary_charge,
+                "charge_increment2": 1.05174 * 0.5 * unit.elementary_charge,
+                "charge_increment3": 1.05174 * 0.5 * unit.elementary_charge,
+                "sigma": 1.0 * unit.nanometer,
             }
         ],
     },

--- a/qubekit/cli/water_models.py
+++ b/qubekit/cli/water_models.py
@@ -91,7 +91,7 @@ water_models = {
             # charge is set to zero as the v-site will move the charge
             {
                 "smirks": "[#1:1]-[#8X2H2+0]-[#1]",
-                "charge1": 0 * unit.elementary_charge,
+                "charge1": 0.52587 * unit.elementary_charge,
                 "id": "q-tip4p-fb-H",
             },
         ],
@@ -109,16 +109,18 @@ water_models = {
                 "sigma": 1 * unit.angstroms,
             },
         ],
-        "VirtualSites": [
+        "LocalCoordinateVirtualSites": [
             {
                 "smirks": "[#1:2]-[#8X2H2+0:1]-[#1:3]",
-                "type": "DivalentLonePair",
-                "distance": -0.10527 * unit.angstroms,
-                "outOfPlaneAngle": 0.0 * unit.degrees,
+                "type": "local",
+                "name": "q-tip4p-fb-v",
+                "x_local": 0.010527 * unit.nanometers,
+                "y_local": 0.0 * unit.nanometers,
+                "z_local": 0.0 * unit.nanometers,
                 "match": "once",
-                "charge_increment1": 0.0 * unit.elementary_charge,
-                "charge_increment2": 1.05174 * 0.5 * unit.elementary_charge,
-                "charge_increment3": 1.05174 * 0.5 * unit.elementary_charge,
+                "charge": -1.05174 * unit.elementary_charge,
+                "sigma": 1 * unit.nanometers,
+                "epsilon": 0.0 * unit.kilojoule_per_mole,
             }
         ],
     },

--- a/qubekit/tests/cli/test_combine.py
+++ b/qubekit/tests/cli/test_combine.py
@@ -634,6 +634,10 @@ def test_molecule_and_vsite_water(coumarin, tmpdir, water, rfree_data):
         combinded_ff = ForceField(
             "combined.offxml", load_plugins=True, allow_cosmetic_attributes=True
         )
+        # make sure the sites are local and we have no normal sites
+        handlers = combinded_ff.registered_parameter_handlers
+        assert "LocalCoordinateVirtualSites" not in handlers
+        assert "VirtualSites" in handlers
         mixed_top = Topology.from_molecules(
             molecules=[
                 Molecule.from_rdkit(water.to_rdkit()),
@@ -843,6 +847,11 @@ def test_molecule_vsite_and_vsite_water_plugin(methanol, tmpdir, water, rfree_da
         combinded_ff = ForceField(
             "combined.offxml", load_plugins=True, allow_cosmetic_attributes=True
         )
+        # make sure the sites are local and we have no normal sites
+        handlers = combinded_ff.registered_parameter_handlers
+        assert "LocalCoordinateVirtualSites" in handlers
+        assert "VirtualSites" not in handlers
+
         mixed_top = Topology.from_molecules(
             molecules=[
                 Molecule.from_rdkit(water.to_rdkit()),

--- a/qubekit/tests/cli/test_combine.py
+++ b/qubekit/tests/cli/test_combine.py
@@ -702,7 +702,7 @@ def test_molecule_and_vsite_water(coumarin, tmpdir, water, rfree_data):
             coumarin_copy.n_atoms + 3
         )
         assert charge == unit.Quantity(-1.05174, unit.elementary_charge)
-        assert sigma == unit.Quantity(0.0, unit.nanometer)
+        assert sigma == unit.Quantity(1.0, unit.nanometer)
         assert epsilon == unit.Quantity(0.0, unit.kilojoule_per_mole)
 
 
@@ -793,7 +793,7 @@ def test_molecule_vsite_and_vsite_water(methanol, tmpdir, water, rfree_data):
             methanol.n_atoms + 3
         )
         assert charge == unit.Quantity(-1.05174, unit.elementary_charge)
-        assert sigma == unit.Quantity(0.0, unit.nanometer)
+        assert sigma == unit.Quantity(1.0, unit.nanometer)
         assert epsilon == unit.Quantity(0.0, unit.kilojoule_per_mole)
 
         # now check the two methanol sites
@@ -911,7 +911,7 @@ def test_molecule_vsite_and_vsite_water_plugin(methanol, tmpdir, water, rfree_da
             methanol.n_atoms + 3
         )
         assert charge == unit.Quantity(-1.05174, unit.elementary_charge)
-        assert sigma == unit.Quantity(0.0, unit.nanometer)
+        assert sigma == unit.Quantity(1.0, unit.nanometer)
         assert epsilon == unit.Quantity(0.0, unit.kilojoule_per_mole)
 
         # now check the two methanol sites


### PR DESCRIPTION
## Description
This PR fixes the local vsite plugin by making it incompatible with the standard vsite handler from openff, we also ensure sites are added to openmm systems and topology in the same order as the reference particles so they can be associated with the correct molecule.  

## Status
- [x] Ready to go