### PR TITLE
Make symmetry codes ints and tuples

### DIFF
--- a/qubekit/molecules/ligand.py
+++ b/qubekit/molecules/ligand.py
@@ -787,7 +787,7 @@ class Molecule(SchemaBase):
     def bond_types(self) -> Dict[str, List[Tuple[int, int]]]:
         """
         Using the symmetry dict, give each bond a code. If any codes match, the bonds can be symmetrised.
-        e.g. bond_symmetry_classes = {(0, 3): '2-0', (0, 4): '2-0', (0, 5): '2-0' ...}
+        e.g. bond_symmetry_classes = {(0, 3): (2, 0), (0, 4): (2, 0), (0, 5): (2, 0) ...}
         all of the above bonds (tuples) are of the same type (methyl H-C bonds in same region)
         This dict is then used to produce bond_types.
         bond_types is just a dict where the keys are the string code from above and the values are all
@@ -797,7 +797,8 @@ class Molecule(SchemaBase):
         bond_symmetry_classes = {}
         for bond in self.bonds:
             bond_symmetry_classes[(bond.atom1_index, bond.atom2_index)] = (
-                f"{atom_types[bond.atom1_index]}-" f"{atom_types[bond.atom2_index]}"
+                atom_types[bond.atom1_index],
+                atom_types[bond.atom2_index],
             )
 
         bond_types = {}
@@ -811,7 +812,7 @@ class Molecule(SchemaBase):
     def angle_types(self) -> Dict[str, List[Tuple[int, int, int]]]:
         """
         Using the symmetry dict, give each angle a code. If any codes match, the angles can be symmetrised.
-        e.g. angle_symmetry_classes = {(1, 0, 3): '3-2-0', (1, 0, 4): '3-2-0', (1, 0, 5): '3-2-0' ...}
+        e.g. angle_symmetry_classes = {(1, 0, 3): (3, 2, 0), (1, 0, 4): (3, 2, 0), (1, 0, 5): (3, 2, 0) ...}
         all of the above angles (tuples) are of the same type (methyl H-C-H angles in same region)
         angle_types is just a dict where the keys are the string code from the above and the values are all
         of the angles with that particular type.
@@ -823,9 +824,9 @@ class Molecule(SchemaBase):
 
         for angle in self.angles:
             angle_symmetry_classes[angle] = (
-                f"{atom_types[angle[0]]}-"
-                f"{atom_types[angle[1]]}-"
-                f"{atom_types[angle[2]]}"
+                atom_types[angle[0]],
+                atom_types[angle[1]],
+                atom_types[angle[2]],
             )
 
         angle_types = {}
@@ -840,7 +841,7 @@ class Molecule(SchemaBase):
         """
         Using the symmetry dict, give each dihedral a code. If any codes match, the dihedrals can be clustered and their
         parameters should be the same, this is to be used in dihedral fitting so all symmetry equivalent dihedrals are
-        optimised at the same time. dihedral_equiv_classes = {(0, 1, 2 ,3): '1-1-2-1'...} all of the tuples are the
+        optimised at the same time. dihedral_equiv_classes = {(0, 1, 2 ,3): (1, 1, 2, 1)...} all of the tuples are the
         dihedrals index by topology and the strings are the symmetry equivalent atom combinations.
         """
 
@@ -852,10 +853,10 @@ class Molecule(SchemaBase):
         for dihedral_set in self.dihedrals.values():
             for dihedral in dihedral_set:
                 dihedral_symmetry_classes[tuple(dihedral)] = (
-                    f"{atom_types[dihedral[0]]}-"
-                    f"{atom_types[dihedral[1]]}-"
-                    f"{atom_types[dihedral[2]]}-"
-                    f"{atom_types[dihedral[3]]}"
+                    atom_types[dihedral[0]],
+                    atom_types[dihedral[1]],
+                    atom_types[dihedral[2]],
+                    atom_types[dihedral[3]],
                 )
 
         dihedral_types = {}
@@ -876,10 +877,10 @@ class Molecule(SchemaBase):
         improper_symmetry_classes = {}
         for dihedral in self.improper_torsions:
             improper_symmetry_classes[tuple(dihedral)] = (
-                f"{atom_types[dihedral[0]]}-"
-                f"{atom_types[dihedral[1]]}-"
-                f"{atom_types[dihedral[2]]}-"
-                f"{atom_types[dihedral[3]]}"
+                atom_types[dihedral[0]],
+                atom_types[dihedral[1]],
+                atom_types[dihedral[2]],
+                atom_types[dihedral[3]],
             )
 
         improper_types = {}
@@ -910,7 +911,7 @@ class Molecule(SchemaBase):
         return new_classes
 
     @property
-    def atom_types(self) -> Dict[int, str]:
+    def atom_types(self) -> Dict[int, int]:
         """Returns a dictionary of atom indices mapped to their class or None if there is no rdkit molecule."""
 
         return RDKit.find_symmetry_classes(self.to_rdkit())

--- a/qubekit/molecules/ligand.py
+++ b/qubekit/molecules/ligand.py
@@ -520,7 +520,7 @@ class Molecule(SchemaBase):
         atom_types = {}
         for atom_index, cip_type in self.atom_types.items():
             atom_types.setdefault(cip_type, []).append((atom_index,))
-        for atoms in atom_types.items():
+        for atoms in atom_types.values():
             self._symmetrise_parameters(
                 force_group=self.NonbondedForce, parameter_keys=atoms
             )

--- a/qubekit/molecules/utils.py
+++ b/qubekit/molecules/utils.py
@@ -285,7 +285,7 @@ class RDKit:
         return [conformer.GetPositions() for conformer in positions]
 
     @staticmethod
-    def find_symmetry_classes(rdkit_mol: Chem.Mol) -> Dict[int, str]:
+    def find_symmetry_classes(rdkit_mol: Chem.Mol) -> Dict[int, int]:
         """
         Generate list of tuples of symmetry-equivalent (homotopic) atoms in the molecular graph
         based on: https://sourceforge.net/p/rdkit/mailman/message/27897393/
@@ -320,7 +320,7 @@ class RDKit:
         # i will be used to define the class (just index based)
         for i, sym_class in enumerate(atom_symmetry_classes):
             for atom in sym_class:
-                atom_symmetry_classes_dict[atom] = str(i)
+                atom_symmetry_classes_dict[atom] = i
 
         return atom_symmetry_classes_dict
 

--- a/qubekit/tests/ligand/ligand_test.py
+++ b/qubekit/tests/ligand/ligand_test.py
@@ -790,6 +790,20 @@ def test_find_rotatable_bonds_indices_of_bonds():
         assert bond in expected_bonds or tuple(reversed(bond)) in expected_bonds
 
 
+def test_no_rotatable_bonds(water):
+    assert 0 == water.n_rotatable_bonds
+
+
+def test_n_rotatable_bonds(methanol):
+    assert 1 == methanol.n_rotatable_bonds
+
+
+def test_measure_no_angles():
+    mol = Ligand.from_smiles("Br", "BrH")
+    assert mol.measure_angles() is None
+    assert not mol.angle_types
+
+
 def test_atom_setup():
     mol = Ligand.from_file(get_data("chloromethane.pdb"))
     ddec_file_path = get_data("DDEC6_even_tempered_net_atomic_charges.xyz")

--- a/qubekit/tests/ligand/parametrisation_test.py
+++ b/qubekit/tests/ligand/parametrisation_test.py
@@ -69,6 +69,21 @@ def test_symm_params_no_angles(tmpdir, openff):
         mol.symmetrise_bonded_parameters()
 
 
+def test_symm_nonbonded_params(tmpdir, openff):
+
+    with tmpdir.as_cwd():
+        mol = Ligand.from_smiles("C", "methane")
+        openff.run(mol)
+        mol.symmetrise_nonbonded_parameters()
+        # make sure all hydrogens have the same parameters
+        p = mol.NonbondedForce[(1,)]
+        for i in range(3):
+            other_p = mol.NonbondedForce[(2 + i,)]
+            assert other_p.charge == p.charge
+            assert other_p.epsilon == p.epsilon
+            assert other_p.sigma == p.sigma
+
+
 def test_openff_skeleton(tmpdir, openff):
     """
     Make sure the skeleton method in openff works when we have missing coverage in the openff forcefield.


### PR DESCRIPTION
## Description
This PR fixes a bug in the valence type grouping method which used strings like `23-33` to build a bond type. The types were then clustered by checking the forward and reversed strings which would fail as the example bond type would become `33-32` and not be grouped correctly, tuples should avoid this issue.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go