### PR TITLE
Use the amoeba plugin handler for Urey-Bradley terms

### DIFF
--- a/qubekit/cli/utils.py
+++ b/qubekit/cli/utils.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 from openff.toolkit.topology import (
     Molecule,
@@ -380,6 +380,28 @@ class LocalCoordinateVirtualSiteHandler(VirtualSiteHandler):
                     system.setVirtualSite(index_system, openmm_particle)
 
         self._create_openff_virtual_sites(matches_by_parent)
+
+    def _find_matches(
+        self,
+        entity: Topology,
+        transformed_dict_cls=dict,
+        unique=False,
+    ) -> Dict[Tuple[int], List[ParameterHandler._Match]]:
+
+        assigned_matches_by_parent = self._find_matches_by_parent(entity)
+        return_dict = {}
+        for parent_index, assigned_parameters in assigned_matches_by_parent.items():
+
+            assigned_matches = []
+            for assigned_parameter, match_orientations in assigned_parameters:
+
+                for match in match_orientations:
+                    assigned_matches.append(
+                        ParameterHandler._Match(assigned_parameter, match)
+                    )
+            return_dict[(parent_index,)] = assigned_matches
+
+        return return_dict
 
 
 class UreyBradleyHandler(ParameterHandler):

--- a/qubekit/forcefield/__init__.py
+++ b/qubekit/forcefield/__init__.py
@@ -7,6 +7,7 @@ from qubekit.forcefield.force_groups import (
     PeriodicTorsionForce,
     RBImproperTorsionForce,
     RBProperTorsionForce,
+    UreyBradleyHarmonicForce,
 )
 from qubekit.forcefield.parameters import (
     BaseParameter,
@@ -18,6 +19,7 @@ from qubekit.forcefield.parameters import (
     LennardJones612Parameter,
     PeriodicTorsionParameter,
     ProperRBTorsionParameter,
+    UreyBradleyHarmonicParameter,
     VirtualSite3Point,
     VirtualSite4Point,
 )
@@ -44,4 +46,6 @@ __all__ = [
     VirtualSite3Point,
     VirtualSite4Point,
     VirtualSiteGroup,
+    UreyBradleyHarmonicParameter,
+    UreyBradleyHarmonicForce,
 ]

--- a/qubekit/forcefield/force_groups.py
+++ b/qubekit/forcefield/force_groups.py
@@ -13,6 +13,7 @@ from qubekit.forcefield.parameters import (
     LennardJones612Parameter,
     PeriodicTorsionParameter,
     ProperRBTorsionParameter,
+    UreyBradleyHarmonicParameter,
 )
 from qubekit.utils.exceptions import MissingParameterError
 
@@ -153,6 +154,24 @@ class HarmonicAngleForce(BaseForceGroup):
     @classmethod
     def symmetry_parameters(cls) -> List[str]:
         return ["angle", "k"]
+
+
+class UreyBradleyHarmonicForce(BaseForceGroup):
+
+    type: Literal["UreyBradleyHarmonicForce"] = "UreyBradleyHarmonicForce"
+    parameters: Optional[List[UreyBradleyHarmonicParameter]] = None
+
+    @classmethod
+    def _parameter_class(cls):
+        return UreyBradleyHarmonicParameter
+
+    @classmethod
+    def openmm_group(cls):
+        return "AmoebaUreyBradleyForce"
+
+    @classmethod
+    def symmetry_parameters(cls) -> List[str]:
+        return ["d", "k"]
 
 
 class PeriodicTorsionForce(BaseForceGroup):

--- a/qubekit/forcefield/parameters.py
+++ b/qubekit/forcefield/parameters.py
@@ -134,6 +134,35 @@ class HarmonicAngleParameter(BaseParameter):
         return "Angle"
 
 
+class UreyBradleyHarmonicParameter(BaseParameter):
+
+    type: Literal["UreyBradleyHarmonicParameter"] = "UreyBradleyHarmonicParameter"
+    k: float = Field(
+        ...,
+        description="The force constant for a harmonic potential in kj/mol/nm**2 representing a U-B "
+        "bond angle cross term. Note our k here is halved when calculating the energy "
+        "which is different to <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4772747/>.",
+    )
+    d: float = Field(
+        ..., description="The equilibrium bond length in the harmonic potential in nm."
+    )
+
+    @classmethod
+    def _n_tags(cls) -> int:
+        return 3
+
+    @classmethod
+    def openmm_type(cls) -> str:
+        return "UreyBradley"
+
+    def xml_data(self) -> Dict[str, str]:
+        xml_data = super().xml_data()
+        # we need to half the k value to get the correct behaviour in OpenMM
+        k = float(xml_data["k"])
+        xml_data["k"] = str(k / 2)
+        return xml_data
+
+
 class PeriodicTorsionParameter(BaseParameter):
 
     type: Literal["PeriodicTorsionParameter"] = "PeriodicTorsionParameter"

--- a/qubekit/molecules/ligand.py
+++ b/qubekit/molecules/ligand.py
@@ -552,9 +552,10 @@ class Molecule(SchemaBase):
                 self._symmetrise_parameters(
                     force_group=self.AngleForce, parameter_keys=angles
                 )
-                self._symmetrise_parameters(
-                    force_group=self.UreyBradleyForce, parameter_keys=angles
-                )
+                if self.UreyBradleyForce.n_parameters > 0:
+                    self._symmetrise_parameters(
+                        force_group=self.UreyBradleyForce, parameter_keys=angles
+                    )
 
         return True
 

--- a/qubekit/molecules/ligand.py
+++ b/qubekit/molecules/ligand.py
@@ -552,6 +552,9 @@ class Molecule(SchemaBase):
                 self._symmetrise_parameters(
                     force_group=self.AngleForce, parameter_keys=angles
                 )
+                self._symmetrise_parameters(
+                    force_group=self.UreyBradleyForce, parameter_keys=angles
+                )
 
         return True
 
@@ -1214,16 +1217,6 @@ class Molecule(SchemaBase):
             topology.addBond(
                 atom1=atom1, atom2=atom2, type=b_type, order=bond.bond_order
             )
-        # # now check for Urey-Bradley terms
-        # for bond in self.BondForce:
-        #     try:
-        #         self.get_bond_between(*bond.atoms)
-        #     except TopologyMismatch:
-        #         # the bond is not in the bond list so add it as a u-b term
-        #         atom1 = top_atoms[bond.atoms[0]]
-        #         atom2 = top_atoms[bond.atoms[1]]
-        #         # this is a fake bond used for U-B terms.
-        #         topology.addBond(atom1=atom1, atom2=atom2, type=Single, order=1)
 
         return topology
 

--- a/qubekit/molecules/ligand.py
+++ b/qubekit/molecules/ligand.py
@@ -31,7 +31,7 @@ from chemper.graphs.cluster_graph import ClusterGraph
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from openff.toolkit.utils.exceptions import ParameterLookupError
 from openmm import unit
-from openmm.app import Aromatic, Double, PDBFile, Single, Topology, Triple
+from openmm.app import Aromatic, Double, Single, Topology, Triple
 from openmm.app.element import Element
 from pydantic import Field, validator
 from qcelemental.models.types import Array
@@ -48,6 +48,7 @@ from qubekit.forcefield import (
     PeriodicTorsionForce,
     RBImproperTorsionForce,
     RBProperTorsionForce,
+    UreyBradleyHarmonicForce,
     VirtualSiteGroup,
 )
 from qubekit.molecules.components import Atom, Bond, TorsionDriveData
@@ -103,6 +104,10 @@ class Molecule(SchemaBase):
     BondForce: Union[HarmonicBondForce] = Field(
         HarmonicBondForce(),
         description="A force object which records bonded interactions between pairs of atoms",
+    )
+    UreyBradleyForce: UreyBradleyHarmonicForce = Field(
+        UreyBradleyHarmonicForce(),
+        description="A force object which records Urey-Bradley bond-angle cross terms.",
     )
     AngleForce: Union[HarmonicAngleForce] = Field(
         HarmonicAngleForce(),
@@ -712,6 +717,13 @@ class Molecule(SchemaBase):
         AngleForce = ET.SubElement(
             root, self.AngleForce.openmm_group(), attrib=self.AngleForce.xml_data()
         )
+        UBForce = ET.SubElement(
+            root,
+            self.UreyBradleyForce.openmm_group(),
+            attrib=self.UreyBradleyForce.xml_data(),
+        )
+        for parameter in self.UreyBradleyForce:
+            ET.SubElement(UBForce, parameter.openmm_type(), attrib=parameter.xml_data())
         for parameter in self.AngleForce:
             ET.SubElement(
                 AngleForce, parameter.openmm_type(), attrib=parameter.xml_data()
@@ -1102,22 +1114,11 @@ class Molecule(SchemaBase):
         )
 
     def has_ub_terms(self) -> bool:
-        """Return `True` if the molecule has Ure-Bradly terms, as there are forces between non-bonded atoms."""
-        for bond in self.BondForce:
-            try:
-                self.get_bond_between(*bond.atoms)
-            except TopologyMismatch:
-                return True
-        return False
+        """Return `True` if the molecule has Urey-Bradley terms, as there are forces between non-bonded atoms."""
+        if self.UreyBradleyForce.n_parameters > 0:
+            return True
 
-    def _to_ub_pdb(self, file_name: Optional[str] = None) -> None:
-        """A privet method to write the molecule to a non-standard pdb file with connections for Urey-Bradly terms."""
-        openmm_top = self.to_openmm_topology()
-        PDBFile.writeFile(
-            topology=openmm_top,
-            positions=self.openmm_coordinates(),
-            file=open(f"{file_name or self.name}.pdb", "w"),
-        )
+        return False
 
     @staticmethod
     def _check_file_name(file_name: str) -> None:
@@ -1213,16 +1214,16 @@ class Molecule(SchemaBase):
             topology.addBond(
                 atom1=atom1, atom2=atom2, type=b_type, order=bond.bond_order
             )
-        # now check for Urey-Bradley terms
-        for bond in self.BondForce:
-            try:
-                self.get_bond_between(*bond.atoms)
-            except TopologyMismatch:
-                # the bond is not in the bond list so add it as a u-b term
-                atom1 = top_atoms[bond.atoms[0]]
-                atom2 = top_atoms[bond.atoms[1]]
-                # this is a fake bond used for U-B terms.
-                topology.addBond(atom1=atom1, atom2=atom2, type=Single, order=1)
+        # # now check for Urey-Bradley terms
+        # for bond in self.BondForce:
+        #     try:
+        #         self.get_bond_between(*bond.atoms)
+        #     except TopologyMismatch:
+        #         # the bond is not in the bond list so add it as a u-b term
+        #         atom1 = top_atoms[bond.atoms[0]]
+        #         atom2 = top_atoms[bond.atoms[1]]
+        #         # this is a fake bond used for U-B terms.
+        #         topology.addBond(atom1=atom1, atom2=atom2, type=Single, order=1)
 
         return topology
 
@@ -1426,11 +1427,10 @@ class Molecule(SchemaBase):
                 angle_data["angle_k"] = (
                     qube_angle.k * unit.kilojoule_per_mole / unit.radians**2
                 )
-                # use the terminal atom to find the bond
-                qube_bond = self.BondForce[(angles[0][0], angles[0][-1])]
-                angle_data["bond_length"] = qube_bond.length * unit.nanometers
+                qube_ub = self.UreyBradleyForce[angles[0]]
+                angle_data["bond_length"] = qube_ub.d * unit.nanometers
                 angle_data["bond_k"] = (
-                    qube_bond.k * unit.kilojoule_per_mole / unit.nanometers**2
+                    qube_ub.k * unit.kilojoule_per_mole / unit.nanometers**2
                 )
             else:
                 angle_data["k"] = (

--- a/qubekit/tests/bonded/qforce_test.py
+++ b/qubekit/tests/bonded/qforce_test.py
@@ -72,8 +72,25 @@ def test_coumarin_run(tmpdir, coumarin):
         qf.run(coumarin)
         assert coumarin.BondForce.n_parameters == coumarin.n_bonds
         assert coumarin.AngleForce.n_parameters == coumarin.n_angles
-        assert coumarin.TorsionForce.n_parameters == 45
+        assert coumarin.UreyBradleyForce.n_parameters == 0
+        assert coumarin.TorsionForce.n_parameters == 50
         assert coumarin.RBTorsionForce.n_parameters == 6
+
+
+def test_coumarin_ub_run(tmpdir, coumarin):
+    """Test running QForce on coumarin and extracting the Urey-Bradley terms"""
+    try:
+        QForceHessianFitting.is_available()
+    except ModuleNotFoundError:
+        pytest.skip("QForce is not available skipping test.")
+
+    with tmpdir.as_cwd():
+        qf = QForceHessianFitting(use_urey_bradley=True)
+        qf.run(coumarin)
+        assert coumarin.BondForce.n_parameters == coumarin.n_bonds
+        assert coumarin.AngleForce.n_parameters == coumarin.n_angles
+        assert coumarin.has_ub_terms() is True
+        assert coumarin.UreyBradleyForce.n_parameters == coumarin.n_angles
 
 
 def test_messages():

--- a/qubekit/tests/cli/test_combine.py
+++ b/qubekit/tests/cli/test_combine.py
@@ -436,14 +436,18 @@ def test_combine_rb_offxml(tmpdir, xml, rfree_data):
         # and no periodic terms
         assert mol.TorsionForce.n_parameters == 0
         # now try and make offxml
-        with pytest.raises(NotImplementedError):
-            _combine_molecules_offxml(
-                molecules=[mol],
-                parameters=elements,
-                rfree_data=rfree_data,
-                filename="test.offxml",
-                h_constraints=False,
-            )
+        _combine_molecules_offxml(
+            molecules=[mol],
+            parameters=elements,
+            rfree_data=rfree_data,
+            filename="test.offxml",
+            h_constraints=False,
+        )
+        ff = ForceField(
+            "test.offxml", load_plugins=True, allow_cosmetic_attributes=True
+        )
+        rb_torsions = ff.get_parameter_handler("ProperRyckhaertBellemans")
+        assert len(rb_torsions.parameters) == 1
 
 
 def test_combine_molecules_deepdiff_offxml(

--- a/qubekit/tests/ligand/ligand_test.py
+++ b/qubekit/tests/ligand/ligand_test.py
@@ -310,42 +310,9 @@ def test_has_ub_terms(acetone, openff):
     assert acetone.has_ub_terms() is False
     # now add a fake terms
     for angle in acetone.angles:
-        acetone.BondForce.create_parameter(atoms=(angle[0], angle[2]), k=1, length=2)
+        acetone.UreyBradleyForce.create_parameter(atoms=angle, k=1, d=2)
 
     assert acetone.has_ub_terms() is True
-
-
-def test_openmm_topology_ub(acetone):
-    """
-    Make sure ub connections are added to a openmm topology when present.
-    """
-    openmm_top_no_ub = acetone.to_openmm_topology()
-    # now add fake ub terms
-    for angle in acetone.angles:
-        acetone.BondForce.create_parameter(atoms=(angle[0], angle[2]), k=1, length=2)
-    openmm_top_ub = acetone.to_openmm_topology()
-    assert openmm_top_ub.getNumBonds() > openmm_top_no_ub.getNumBonds()
-    assert openmm_top_ub.getNumAtoms() == openmm_top_no_ub.getNumAtoms()
-
-
-def test_ub_pdb(acetone, tmpdir):
-    """
-    Make sure we can write pdb files which have the ub connections.
-    """
-    with tmpdir.as_cwd():
-        # add fake ub terms
-        for angle in acetone.angles:
-            acetone.BondForce.create_parameter(
-                atoms=(angle[0], angle[2]), k=1, length=2
-            )
-        # write out the pdb file
-        acetone._to_ub_pdb()
-        # try and read in the malformed pdb with extra connections
-        with pytest.raises(
-            AtomValenceException,
-            match="Explicit valence for atom # 0 C, 6, is greater than permitted",
-        ):
-            _ = Ligand.from_file("acetone.pdb")
 
 
 @pytest.mark.parametrize(

--- a/qubekit/tests/ligand/ligand_test.py
+++ b/qubekit/tests/ligand/ligand_test.py
@@ -9,7 +9,6 @@ import pytest
 from openff.toolkit.topology import Molecule as OFFMolecule
 from openmm import unit
 from rdkit.Chem import rdMolTransforms
-from rdkit.Chem.rdchem import AtomValenceException
 
 from qubekit.charges import ExtractChargeData
 from qubekit.molecules import Ligand

--- a/qubekit/tests/ligand/parametrisation_test.py
+++ b/qubekit/tests/ligand/parametrisation_test.py
@@ -678,13 +678,11 @@ def test_vsite_handler_labeling(methanol, tmpdir):
         vsite_handler = ff.get_parameter_handler("LocalCoordinateVirtualSites")
         assert len(vsite_handler.parameters) == 2
         off_mol = Molecule.from_rdkit(methanol.to_rdkit())
-        vsite_labels = ff.label_molecules(topology=off_mol.to_topology())[0][
-            "LocalCoordinateVirtualSites"
-        ]
+        matches = vsite_handler._find_matches(entity=off_mol.to_topology())
         # they should only be on the oxygen atom
-        assert len(vsite_labels) == 1
+        assert len(matches) == 1
         # there should be a lone pair on the oxygen
-        assert len(vsite_labels[(1,)]) == 2
+        assert len(matches[(1,)]) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
This PR updates the old handling of Urey-Bradley terms from QForce to use a dedicated handler in QUBEKit. These are now exported to OpenMM via the AMOEBA plugin handler which means they can be loaded with no virtual bonds and will have the correct non-bonded exceptions.

## Status
- [x] Ready to go