### PR TITLE
Old PCMsolver overwrite the pyparsing package

### DIFF
--- a/devtools/conda-envs/everything.yaml
+++ b/devtools/conda-envs/everything.yaml
@@ -32,6 +32,7 @@ dependencies:
   - qcelemental >=0.19.0
   - jinja2
   - typing-extensions
+  - pcmsolver >=1.2.1
 
   # Optional
   - xtb-python


### PR DESCRIPTION
Matplotlib complains about pyparsing having the wrong version: "ImportError: Matplotlib requires pyparsing>=2.0.1"; you have 1.5.0. Pyparsing package has the right version, but there is a file pyparsing.py in the conda/bin which belongs to the pcmsolver=1.1.4 from the psi4 channel. The new one pcmsolver-1.2.1 resolves this issue.


## Status
- [x] Ready to go