### PR TITLE
Pin forcebalance in CI

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -25,7 +25,7 @@ dependencies:
   - click
   - chargemol
   - qcelemental >=0.19.0
-  - forcebalance
+  - forcebalance=1.9.3
   - pymbar=3.0.7
   - jinja2
   - typing-extensions

--- a/devtools/conda-envs/everything.yaml
+++ b/devtools/conda-envs/everything.yaml
@@ -17,7 +17,7 @@ dependencies:
   - openff-fragmenter
   - ambertools
   - pydantic
-  - forcebalance
+  - forcebalance=1.9.3
   - pymbar=3.0.7
   - rdkit
   - tqdm


### PR DESCRIPTION
## Description
Fix the CI by pinning the forcebalance version as the recipe allows for incompatible versions of the openff-toolkit-base.

## Status
- [x] Ready to go