### PR TITLE
Fix optional stages

### DIFF
--- a/qubekit/tests/workflow/test_workflow.py
+++ b/qubekit/tests/workflow/test_workflow.py
@@ -100,14 +100,22 @@ def test_build_results_optional(acetone):
     "skip_stages",
     [pytest.param(["charges", "hessian"], id="stages"), pytest.param(None, id="None")],
 )
-def test_optional_stage_skip(skip_stages):
+@pytest.mark.parametrize(
+    "optional_stage",
+    [
+        pytest.param("virtual_sites", id="vsites"),
+        pytest.param("fragmentation", id="fragmentation"),
+    ],
+)
+def test_optional_stage_skip(skip_stages, optional_stage):
     """
     Test adding the optional stages to the skip list.
     """
     # has no vsite stage
     model0 = get_workflow_protocol(workflow_protocol="0")
+    setattr(model0, optional_stage, None)
     skips = model0._get_optional_stage_skip(skip_stages=skip_stages)
-    assert "virtual_sites" in skips
+    assert optional_stage in skips
 
 
 def test_run_workflow(acetone, tmpdir, rdkit_workflow):


### PR DESCRIPTION
## Description
This PR fixes the running of workflows with optional stages. Fragmentation was introduced as an optional stage but only vsites were hardcoded as an optional stage meaning the workflow would error when ran with fragmentation as `None`. This is now fixed by checking each stage in the normal workflow and if that stage is `None` it is added to the skipped stages list. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Test the workflow runs with optional stages

## Questions
- [ ] Question1

## Status
- [x] Ready to go