### PR TITLE
Volume unit fix

### DIFF
--- a/qubekit/cli/combine.py
+++ b/qubekit/cli/combine.py
@@ -242,7 +242,7 @@ def _combine_molecules_offxml(
             if using_plugin:
                 # this is to be refit
                 atom = molecule.atoms[qube_non_bond.atoms[0]]
-                atom_data["volume"] = atom.aim.volume * unit.angstroms**3
+                atom_data["volume"] = atom.aim.volume * unit.bohr**3
             else:
                 atom_data["epsilon"] = qube_non_bond.epsilon * unit.kilojoule_per_mole
                 atom_data["sigma"] = qube_non_bond.sigma * unit.nanometers

--- a/qubekit/cli/utils.py
+++ b/qubekit/cli/utils.py
@@ -165,7 +165,7 @@ class QUBEKitHandler(vdWHandler):
                 )
                 for match in matches:
                     qb_mol.atoms[match[0]].aim.volume = parameter.volume.value_in_unit(
-                        unit.angstroms**3
+                        unit.bohr**3
                     )
             # make sure all atoms in the molecule have volumes, assign dummy values
             for i in range(qb_mol.n_atoms):


### PR DESCRIPTION
## Description
This PR fixes the units for the AIM volumes to be in bohr^3 as they should be. Currently, they are set as angstroms^3 and then requested in angstroms^3 so no conversion happens, this fix will break old offxml files with incorrect units. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Make sure that values are consistent with new offxml files

## Questions
- [ ] Question1

## Status
- [x] Ready to go