### PR TITLE
Alpha and beta scaling with transfered polar H terms

### DIFF
--- a/qubekit/cli/utils.py
+++ b/qubekit/cli/utils.py
@@ -83,6 +83,9 @@ class QUBEKitHandler(vdWHandler):
     sifree = ParameterAttribute(0 * unit.angstroms, unit=unit.angstroms)
     alpha = ParameterAttribute(1)
     beta = ParameterAttribute(0)
+    lj_on_polar_h = ParameterAttribute(
+        default="True", converter=_allow_only(["True", "False"])
+    )
 
     class QUBEKitvdWType(ParameterType):
         """A dummy vdw type which just stores the volume and so we can build the system correctly"""
@@ -145,6 +148,7 @@ class QUBEKitHandler(vdWHandler):
             },
             alpha=self.alpha,
             beta=self.beta,
+            lj_on_polar_h=self.lj_on_polar_h,
         )
 
         water = Molecule.from_smiles("O")

--- a/qubekit/nonbonded/lennard_jones.py
+++ b/qubekit/nonbonded/lennard_jones.py
@@ -119,11 +119,15 @@ class LennardJones612(StageBase):
                 # Find polar Hydrogens and allocate their new name: X
                 if atomic_symbol == "H":
                     bonded_index = atom.bonds[0]
-                    if molecule.atoms[bonded_index].atomic_symbol in [
-                        "N",
-                        "O",
-                        "S",
-                    ]:
+                    if (
+                        molecule.atoms[bonded_index].atomic_symbol
+                        in [
+                            "N",
+                            "O",
+                            "S",
+                        ]
+                        and self.lj_on_polar_h
+                    ):
                         atomic_symbol = "X"
 
                 # r_aim = r_free * ((vol / v_free) ** (1 / 3))
@@ -132,8 +136,13 @@ class LennardJones612(StageBase):
                 )
 
                 # b_i = bfree * ((vol / v_free) ** 2)
-                b_i = self.free_parameters[atomic_symbol].b_free * (
-                    (atom_vol / self.free_parameters[atomic_symbol].v_free) ** 2
+                b_i = (
+                    self.free_parameters[atomic_symbol].b_free
+                    * self.alpha
+                    * (
+                        (atom_vol / self.free_parameters[atomic_symbol].v_free)
+                        ** (2 + self.beta)
+                    )
                 )
 
                 a_i = 32 * b_i * (r_aim**6)
@@ -239,10 +248,10 @@ class LennardJones612(StageBase):
                 epsilon = (lj_datum.b_i * lj_datum.b_i) / (4 * lj_datum.a_i)
 
                 # alpha and beta
-                epsilon *= self.alpha * (
-                    (atom.aim.volume / self.free_parameters[atom.atomic_symbol].v_free)
-                    ** self.beta
-                )
+                # epsilon *= self.alpha * (
+                #     (atom.aim.volume / self.free_parameters[atom.atomic_symbol].v_free)
+                #     ** self.beta
+                # )
                 epsilon *= constants.EPSILON_CONVERSION
 
             non_bonded_forces[atom.atom_index] = (sigma, epsilon)


### PR DESCRIPTION
## Description
This PR changes when the alpha and beta scaling are applied during the LJ derivation stage to allow them to be applied to polar Hs before being transferred to the parent atoms. So a scaled C6 term is derived for each atom then C6 prime on the parent is calculated from these terms.

This also fixes a bug in the polar h transfer code where the transfer was missed in protocol 4a as it assumed the presence of a polar H Rfree term under the normal key `X` which is not needed. Tests have been added to capture this failure in future and the reference values have been calculated by hand using the data in the `methanol.json` model in the data folder.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [x] Expose as a flag when making the combined offxml? This will then remove the parameterization flag for the polar H as we don't want to take the gradient of the parameter which does not affect the parameters.
- [ ] This makes the XML combining code more complicated should we remove it as we can do everything via offxml now?

## Status
- [x] Ready to go