### PR TITLE
Update finall outputs

### DIFF
--- a/qubekit/workflow/workflow.py
+++ b/qubekit/workflow/workflow.py
@@ -318,9 +318,14 @@ class WorkFlow(SchemaBase):
         # write out final parameters
         with folder_setup("final_parameters"):
             molecule.to_file(file_name=f"{molecule.name}.pdb")
+            molecule.to_file(file_name=f"{molecule.name}.sdf")
             molecule.write_parameters(file_name=f"{molecule.name}.xml")
             # write out the offxml with h-bond constraints
             molecule.to_offxml(file_name=f"{molecule.name}.offxml", h_constraints=True)
+            # write without h-constraints
+            molecule.to_offxml(
+                file_name=f"{molecule.name}_unconstrained.offxml", h_constraints=False
+            )
 
         return results
 


### PR DESCRIPTION
## Description
This PR updates the final outputs of a QUBEKit run to include an offxml with and without H-bond constraints (has `_unconstrained` suffix) and a pdb and sdf file of the molecule. Thus the final parameters can be used in OpenMM directly (pdb + XML) or via the openff-toolkit (sdf + offxml). 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go