### PR TITLE
Fragmentation: a fragment should not be a subset of another fragment

### DIFF
--- a/qubekit/data/integration_workflow.json
+++ b/qubekit/data/integration_workflow.json
@@ -54,7 +54,7 @@
   },
   "optimisation": {
     "type": "Optimiser",
-    "pre_optimisation_method": "gfn2xtb",
+    "pre_optimisation_method": "ani1ccx",
     "seed_conformers": 40,
     "maxiter": 350,
     "convergence_criteria": "GAU_TIGHT"

--- a/qubekit/data/integration_workflow.json
+++ b/qubekit/data/integration_workflow.json
@@ -54,7 +54,7 @@
   },
   "optimisation": {
     "type": "Optimiser",
-    "pre_optimisation_method": "ani1ccx",
+    "pre_optimisation_method": "gfn2xtb",
     "seed_conformers": 40,
     "maxiter": 350,
     "convergence_criteria": "GAU_TIGHT"

--- a/qubekit/fragmentation/wbo_fragmenter.py
+++ b/qubekit/fragmentation/wbo_fragmenter.py
@@ -101,6 +101,7 @@ class WBOFragmentation(StageBase, WBOFragmenter):
 
         # sort first by size in decreasing order
         from rdkit import Chem
+
         sorted_frags = sorted(fragments, key=lambda f: len(f.atoms), reverse=True)
 
         substructures = []
@@ -110,9 +111,11 @@ class WBOFragmentation(StageBase, WBOFragmenter):
             if i in substructures:
                 continue
 
-            for j, f_smaller in enumerate(sorted_frags[i+1:], start=i+1):
+            for j, f_smaller in enumerate(sorted_frags[i + 1 :], start=i + 1):
                 # ignore the hydrogens
-                if Chem.RemoveHs(f_larger.to_rdkit()).HasSubstructMatch(Chem.RemoveHs(f_smaller.to_rdkit())):
+                if Chem.RemoveHs(f_larger.to_rdkit()).HasSubstructMatch(
+                    Chem.RemoveHs(f_smaller.to_rdkit())
+                ):
                     # mark that this fragment is contained by another one
                     substructures.append(j)
 
@@ -120,8 +123,11 @@ class WBOFragmentation(StageBase, WBOFragmenter):
                     f_larger.bond_indices.extend(f_smaller.bond_indices)
 
         # return the fragments without the "subfragments"
-        fragments_without_substructures = [fragment for i, fragment in enumerate(sorted_frags)
-                                           if i not in substructures]
+        fragments_without_substructures = [
+            fragment
+            for i, fragment in enumerate(sorted_frags)
+            if i not in substructures
+        ]
         return fragments_without_substructures
 
     def _deduplicate_fragments(
@@ -179,7 +185,9 @@ class WBOFragmentation(StageBase, WBOFragmenter):
             unique_fragments.append(fragments_assymetry[0])
 
         # merge any fragments that are subsets into the larger fragment
-        grouped_fragments = WBOFragmentation._group_subfragments_together(unique_fragments)
+        grouped_fragments = WBOFragmentation._group_subfragments_together(
+            unique_fragments
+        )
 
         # re number the unique fragments
         for i, fragment in enumerate(grouped_fragments):

--- a/qubekit/fragmentation/wbo_fragmenter.py
+++ b/qubekit/fragmentation/wbo_fragmenter.py
@@ -178,8 +178,7 @@ class WBOFragmentation(StageBase, WBOFragmenter):
             ]
             unique_fragments.append(fragments_assymetry[0])
 
-        # check if the fragments are substructures of other fragmetns, if they are, use the larger fragments instead,
-        # and add to them the bond_indices from the smaller fragments,
+        # join any fragments that are subsets to other fragments
         grouped_fragments = WBOFragmentation._group_subfragments_together(unique_fragments)
 
         # re number the unique fragments

--- a/qubekit/fragmentation/wbo_fragmenter.py
+++ b/qubekit/fragmentation/wbo_fragmenter.py
@@ -178,7 +178,7 @@ class WBOFragmentation(StageBase, WBOFragmenter):
             ]
             unique_fragments.append(fragments_assymetry[0])
 
-        # join any fragments that are subsets to other fragments
+        # merge any fragments that are subsets into the larger fragment
         grouped_fragments = WBOFragmentation._group_subfragments_together(unique_fragments)
 
         # re number the unique fragments

--- a/qubekit/fragmentation/wbo_fragmenter.py
+++ b/qubekit/fragmentation/wbo_fragmenter.py
@@ -94,29 +94,32 @@ class WBOFragmentation(StageBase, WBOFragmenter):
 
     @staticmethod
     def _group_subfragments_together(fragments):
-        # modifies the fragments
-        # some fragments are subfragments of other fragments, group together
-        # sort first by size, largest first
-        # f.to_rdkit().HasSubstructMatch()
-        sorted_frags = sorted(fragments, key=lambda f: len(f.atoms), reverse=True)
+        """
+        When a fragment is contained by another, merge them into the bigger one.
+        Warning: Modifies the list of fragments (and some fragments).
+        """
+
+        # sort first by size in decreasing order
         from rdkit import Chem
+        sorted_frags = sorted(fragments, key=lambda f: len(f.atoms), reverse=True)
 
         substructures = []
         for i, f_larger in enumerate(sorted_frags):
-            # if this fragment already is a substructure of another fragment,
-            # then it does not matter that it is a superstructure to another fragment
+            # if this fragment already is contained by another fragment,
+            # then it does not matter that if it contains other fragments
             if i in substructures:
                 continue
 
             for j, f_smaller in enumerate(sorted_frags[i+1:], start=i+1):
+                # ignore the hydrogens
                 if Chem.RemoveHs(f_larger.to_rdkit()).HasSubstructMatch(Chem.RemoveHs(f_smaller.to_rdkit())):
-                    # avoid considering this fragment as a parent to another fragment
+                    # mark that this fragment is contained by another one
                     substructures.append(j)
 
                     # merge the smaller structure into the larger structure
                     f_larger.bond_indices.extend(f_smaller.bond_indices)
 
-        # return fragments without the substructures
+        # return the fragments without the "subfragments"
         fragments_without_substructures = [fragment for i, fragment in enumerate(sorted_frags)
                                            if i not in substructures]
         return fragments_without_substructures
@@ -177,7 +180,7 @@ class WBOFragmentation(StageBase, WBOFragmenter):
 
         # check if the fragments are substructures of other fragmetns, if they are, use the larger fragments instead,
         # and add to them the bond_indices from the smaller fragments,
-        grouped_fragments = self._group_subfragments_together(unique_fragments)
+        grouped_fragments = WBOFragmentation._group_subfragments_together(unique_fragments)
 
         # re number the unique fragments
         for i, fragment in enumerate(grouped_fragments):


### PR DESCRIPTION
When a fragment is a subfragment to anoher one, it leads to DuplicateParameterError. In many cases, it might be faster of equivalent to merge them in this case. 

This fix was tested on the cases that had the original issue, showing similar performance:
 - lig_CHEMBL3264995-1: 10h now vs 8h broken without FB
 - lig_CHEMBL3264997-1: 8h now vs 6.5h without FB
 - lig_CHEMBL3265035-1: 5h now vs 4h without FB
 - lig_CHEMBL3265035-2: 5h now vs 4h without FB

## Todos
  - [ ] Verify that the resulting FF is correct

## Status
- [ ] Ready to go