### PR TITLE
Fix coordinate check

### DIFF
--- a/qubekit/molecules/ligand.py
+++ b/qubekit/molecules/ligand.py
@@ -1276,10 +1276,10 @@ class Molecule(SchemaBase):
         """
         import copy
 
-        # make sure we have a conformer
-        if self.coordinates == [] or self.coordinates is None:
+        # make sure we have a valid conformer
+        if self.coordinates is None or self.coordinates.shape != (self.n_atoms, 3):
             raise ConformerError(
-                "The molecule must have a conformation to make a qcschema molecule."
+                "The molecule must have a valid conformation to make a qcschema molecule."
             )
         coords = copy.deepcopy(self.coordinates)
         # input must be in bohr


### PR DESCRIPTION
## Description
This PR fixes a recent testing failure caused when checking for coordinates before converting the QUBEKit Ligand to qcschema. The issue is caused by comparing a numpy array with an empty list, as we use pydantic to enforce the types we will always have a numpy array or `None` so we can just check the shape of the array.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go