### PR TITLE
Offxml impropers

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -14,7 +14,7 @@ dependencies:
   # Core deps
   - openff-toolkit-base >=0.10.7, <0.11
   - openff-fragmenter
-  - pydantic
+  - pydantic >1, <2
   - rdkit
   - torsiondrive
   - numpy >=1.18.1

--- a/devtools/conda-envs/everything.yaml
+++ b/devtools/conda-envs/everything.yaml
@@ -18,7 +18,7 @@ dependencies:
   - pytorch
   - openff-fragmenter=0.1.2
   - ambertools
-  - pydantic
+  - pydantic >1, <2
   - forcebalance=1.9.3
   - pymbar=3.0.7
   - rdkit

--- a/qubekit/cli/combine.py
+++ b/qubekit/cli/combine.py
@@ -223,7 +223,8 @@ def _combine_molecules_offxml(
         molecule._build_offxml_bonds(offxml=offxml)
         molecule._build_offxml_angles(offxml=offxml)
         molecule._build_offxml_torsions(offxml=offxml, parameterize=False)
-        molecule._build_offxml_improper_torsions(offxml=offxml)
+        if molecule.ImproperTorsionForce.n_parameters > 0:
+            molecule._build_offxml_improper_torsions(offxml=offxml)
         if molecule.RBTorsionForce.n_parameters > 0:
             molecule._build_offxml_rb_torsions(offxml=offxml)
         molecule._build_offxml_charges(offxml=offxml)

--- a/qubekit/tests/conftest.py
+++ b/qubekit/tests/conftest.py
@@ -128,3 +128,11 @@ def biphenyl():
     )
     mol.add_qm_scan(scan_data=td_data)
     return mol
+
+
+@pytest.fixture()
+def cyclohexylamine():
+    """
+    Load up Cyclohexylamine as a molecule with improper torsions formally but no improper torsion parameters assigned.
+    """
+    return Ligand.from_smiles("NC1CCCCC1", "cyclohexylamine")


### PR DESCRIPTION
## Description
This PR fixes the combine command to work with molecules which formally have an improper angle but no improper torsion parameter assigned by the reference force field a test for `cyclohexylamine` is included.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [x] Ready to go